### PR TITLE
Support HTML previews

### DIFF
--- a/settings_example.toml
+++ b/settings_example.toml
@@ -34,6 +34,13 @@ allowlist = ["<REPLACE_WITH_USERNAME>@gmail.com"]
 client_id = ""
 client_secret = ""
 
+[ui]
+# data_types that will be rendered using unescaped HTML in a sandboxed iframe in the
+# frontend UI.
+allowed_data_types_preview = [
+    "openrelik:worker:hayabusa:file:html"
+]
+
 # Enable cloud features such as adding cloud disks.
 # This requires your OpenRelik installation to run on cloud VMs.
 [cloud.gcp]

--- a/src/api/v1/configs.py
+++ b/src/api/v1/configs.py
@@ -21,18 +21,20 @@ router = APIRouter()
 
 @router.get("/system/")
 def get_system_config():
-    llms = config.get("llms", [])
+    _llms = config.get("llms", [])
     active_llms = [
-        service for service in llms.values() if service.get("enabled", False)
-    ]
-    data_types = [
-        "text/csv",
-        "text/json",
+        service for service in _llms.values() if service.get("enabled", False)
     ]
     active_cloud = get_active_cloud_provider()
 
+    # Data types that will be allowed to be returned as unescaped HTML for use in
+    # sandboxed iframe preview.
+    allowed_data_types_preview = config.get("ui", {}).get(
+        "allowed_data_types_preview", []
+    )
+
     return {
         "active_llms": active_llms,
-        "data_types": data_types,
+        "allowed_data_types_preview": allowed_data_types_preview,
         "active_cloud": active_cloud,
     }

--- a/src/mediator/mediator.py
+++ b/src/mediator/mediator.py
@@ -107,6 +107,7 @@ def process_successful_task(db, celery_task, db_task, celery_app):
     for file_data in result_dict.get("output_files", []):
         workflow = get_workflow_from_db(db, result_dict.get("workflow_id"))
         display_name = file_data.get("display_name")
+        data_type = file_data.get("data_type")
         file_uuid = uuid.UUID(file_data.get("uuid"))
         _, file_extension = os.path.splitext(display_name)
         new_file = schemas.FileCreate(
@@ -114,6 +115,7 @@ def process_successful_task(db, celery_task, db_task, celery_app):
             uuid=file_uuid,
             filename=display_name,
             extension=file_extension.lstrip("."),
+            data_type=data_type,
             folder_id=workflow.folder.id,
             user_id=workflow.user.id,
             task_output_id=db_task.id,


### PR DESCRIPTION
This PR adds support for returning unescaped HTML from allowed sources.

Worker that outputs HTML reports can be rendered in the frontend. 
* You need to add the data_type to the allowed data_types for previews (in settings.toml)
* Content is rendered in a sandboxed iframe on the client (no scripts or external resources etc)
