### PR TITLE
Remove extension from filenames on disk.

### DIFF
--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -44,9 +44,7 @@ from . import schemas
 router = APIRouter()
 
 # File types that are trusted to be returned unescaped to the client
-ALLOWED_DATA_TYPES_PREVIEW = config.get("ui",
-                                        {}).get("allowed_data_types_preview",
-                                                [])
+ALLOWED_DATA_TYPES_PREVIEW = config.get("ui", {}).get("allowed_data_types_preview", [])
 
 
 # Get file
@@ -61,10 +59,10 @@ def get_file(
 # Get file content
 @router.get("/{file_id}/content", response_class=HTMLResponse)
 def get_file_content(
-        file_id: str,
-        theme: str = "light",
-        unescaped: bool = False,
-        db: Session = Depends(get_db_connection),
+    file_id: str,
+    theme: str = "light",
+    unescaped: bool = False,
+    db: Session = Depends(get_db_connection),
 ):
     file = get_file_from_db(db, file_id)
     encodings_to_try = ["utf-8", "utf-16", "ISO-8859-1"]
@@ -113,8 +111,7 @@ def download_file(file_id: int, db: Session = Depends(get_db_connection)):
 
 # Download file stream
 @router.get("/{file_id}/download_stream")
-async def download_file_stream(file_id: int,
-                               db: Session = Depends(get_db_connection)):
+async def download_file_stream(file_id: int, db: Session = Depends(get_db_connection)):
     file = get_file_from_db(db, file_id)
     file_path = file.path
     CHUNK_SIZE = 10 * 1024 * 1024  # 10MB
@@ -130,9 +127,9 @@ async def download_file_stream(file_id: int,
         "Content-Length": str(file.filesize),
     }
 
-    return StreamingResponse(iterfile(),
-                             headers=headers,
-                             media_type="application/octet-stream")
+    return StreamingResponse(
+        iterfile(), headers=headers, media_type="application/octet-stream"
+    )
 
 
 # Delete file
@@ -237,10 +234,10 @@ def get_workflows(
 # Get task
 @router.get("/{file_id}/workflows/{workflow_id}/tasks/{task_id}")
 def get_task(
-        file_id: int,
-        workflow_id: int,
-        task_id: int,
-        db: Session = Depends(get_db_connection),
+    file_id: int,
+    workflow_id: int,
+    task_id: int,
+    db: Session = Depends(get_db_connection),
 ) -> List[schemas.Task]:
     return get_task_from_db(db, task_id)
 
@@ -248,10 +245,10 @@ def get_task(
 # Download task result file
 @router.post("/{file_id}/workflows/{workflow_id}/tasks/{task_id}/download")
 def download_task_result(
-        file_id: int,
-        workflow_id: int,
-        task_id: str,
-        db: Session = Depends(get_db_connection),
+    file_id: int,
+    workflow_id: int,
+    task_id: str,
+    db: Session = Depends(get_db_connection),
 ):
     task = db.get(Task, task_id)
     result = json.loads(task.result)
@@ -267,21 +264,22 @@ def download_task_result(
     )
 
 
-@router.get("/{file_id}/summaries/{summary_id}",
-            response_model=schemas.FileSummaryResponse)
+@router.get(
+    "/{file_id}/summaries/{summary_id}", response_model=schemas.FileSummaryResponse
+)
 def get_file_summary(
-        file_id: int,
-        summary_id: int,
-        db: Session = Depends(get_db_connection),
+    file_id: int,
+    summary_id: int,
+    db: Session = Depends(get_db_connection),
 ):
     return get_file_summary_from_db(db, summary_id)
 
 
 @router.post("/{file_id}/summaries")
 def generate_file_summary(
-        file_id: int,
-        background_tasks: BackgroundTasks,
-        db: Session = Depends(get_db_connection),
+    file_id: int,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db_connection),
 ):
 
     new_file_summary = schemas.FileSummaryCreate(

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -44,7 +44,9 @@ from . import schemas
 router = APIRouter()
 
 # File types that are trusted to be returned unescaped to the client
-ALLOWED_DATA_TYPES_PREVIEW = config.get("ui", {}).get("allowed_data_types_preview", [])
+ALLOWED_DATA_TYPES_PREVIEW = config.get("ui",
+                                        {}).get("allowed_data_types_preview",
+                                                [])
 
 
 # Get file
@@ -59,10 +61,10 @@ def get_file(
 # Get file content
 @router.get("/{file_id}/content", response_class=HTMLResponse)
 def get_file_content(
-    file_id: str,
-    theme: str = "light",
-    unescaped: bool = False,
-    db: Session = Depends(get_db_connection),
+        file_id: str,
+        theme: str = "light",
+        unescaped: bool = False,
+        db: Session = Depends(get_db_connection),
 ):
     file = get_file_from_db(db, file_id)
     encodings_to_try = ["utf-8", "utf-16", "ISO-8859-1"]
@@ -111,7 +113,8 @@ def download_file(file_id: int, db: Session = Depends(get_db_connection)):
 
 # Download file stream
 @router.get("/{file_id}/download_stream")
-async def download_file_stream(file_id: int, db: Session = Depends(get_db_connection)):
+async def download_file_stream(file_id: int,
+                               db: Session = Depends(get_db_connection)):
     file = get_file_from_db(db, file_id)
     file_path = file.path
     CHUNK_SIZE = 10 * 1024 * 1024  # 10MB
@@ -127,9 +130,9 @@ async def download_file_stream(file_id: int, db: Session = Depends(get_db_connec
         "Content-Length": str(file.filesize),
     }
 
-    return StreamingResponse(
-        iterfile(), headers=headers, media_type="application/octet-stream"
-    )
+    return StreamingResponse(iterfile(),
+                             headers=headers,
+                             media_type="application/octet-stream")
 
 
 # Delete file
@@ -155,7 +158,7 @@ async def create_file(
     for file in files:
         _, file_extension = os.path.splitext(file.filename)
         uuid = uuid4()
-        output_filename = f"{uuid.hex}{file_extension}"
+        output_filename = f"{uuid.hex}"
         output_path = os.path.join(folder.path, output_filename)
         async with aiofiles.open(output_path, "wb") as fh:
             while content := await file.read(1024000):  # Read 1MB chunks
@@ -234,10 +237,10 @@ def get_workflows(
 # Get task
 @router.get("/{file_id}/workflows/{workflow_id}/tasks/{task_id}")
 def get_task(
-    file_id: int,
-    workflow_id: int,
-    task_id: int,
-    db: Session = Depends(get_db_connection),
+        file_id: int,
+        workflow_id: int,
+        task_id: int,
+        db: Session = Depends(get_db_connection),
 ) -> List[schemas.Task]:
     return get_task_from_db(db, task_id)
 
@@ -245,10 +248,10 @@ def get_task(
 # Download task result file
 @router.post("/{file_id}/workflows/{workflow_id}/tasks/{task_id}/download")
 def download_task_result(
-    file_id: int,
-    workflow_id: int,
-    task_id: str,
-    db: Session = Depends(get_db_connection),
+        file_id: int,
+        workflow_id: int,
+        task_id: str,
+        db: Session = Depends(get_db_connection),
 ):
     task = db.get(Task, task_id)
     result = json.loads(task.result)
@@ -264,22 +267,21 @@ def download_task_result(
     )
 
 
-@router.get(
-    "/{file_id}/summaries/{summary_id}", response_model=schemas.FileSummaryResponse
-)
+@router.get("/{file_id}/summaries/{summary_id}",
+            response_model=schemas.FileSummaryResponse)
 def get_file_summary(
-    file_id: int,
-    summary_id: int,
-    db: Session = Depends(get_db_connection),
+        file_id: int,
+        summary_id: int,
+        db: Session = Depends(get_db_connection),
 ):
     return get_file_summary_from_db(db, summary_id)
 
 
 @router.post("/{file_id}/summaries")
 def generate_file_summary(
-    file_id: int,
-    background_tasks: BackgroundTasks,
-    db: Session = Depends(get_db_connection),
+        file_id: int,
+        background_tasks: BackgroundTasks,
+        db: Session = Depends(get_db_connection),
 ):
 
     new_file_summary = schemas.FileSummaryCreate(

--- a/src/datastores/sql/crud/file.py
+++ b/src/datastores/sql/crud/file.py
@@ -34,8 +34,7 @@ def get_files_from_db(db: Session, folder_id: int):
     Returns:
         List[File]: A list of File objects representing the files in the folder.
     """
-    return db.query(File).filter_by(folder_id=folder_id).order_by(
-        File.id.desc()).all()
+    return db.query(File).filter_by(folder_id=folder_id).order_by(File.id.desc()).all()
 
 
 def get_file_from_db(db: Session, file_id: int):
@@ -63,7 +62,7 @@ def create_file_in_db(db: Session, file: schemas.FileCreate):
     """
     folder = get_folder_from_db(db, file.folder_id)
     uuid = file.uuid
-    filename = f'{uuid.hex}'
+    filename = f"{uuid.hex}"
     output_file = os.path.join(folder.path, filename)
 
     # File metadata
@@ -97,8 +96,7 @@ def get_file_summary_from_db(db: Session, file_summary_id: int):
     return db.get(FileSummary, file_summary_id)
 
 
-def create_file_summary_in_db(db: Session,
-                              file_summary: schemas.FileSummaryCreate):
+def create_file_summary_in_db(db: Session, file_summary: schemas.FileSummaryCreate):
     """Creates a new file summary in the database using generative AI.
 
     Args:

--- a/src/datastores/sql/crud/file.py
+++ b/src/datastores/sql/crud/file.py
@@ -20,7 +20,6 @@ from api.v1 import schemas
 
 from .folder import get_folder_from_db
 
-
 import magic
 import os
 
@@ -35,7 +34,8 @@ def get_files_from_db(db: Session, folder_id: int):
     Returns:
         List[File]: A list of File objects representing the files in the folder.
     """
-    return db.query(File).filter_by(folder_id=folder_id).order_by(File.id.desc()).all()
+    return db.query(File).filter_by(folder_id=folder_id).order_by(
+        File.id.desc()).all()
 
 
 def get_file_from_db(db: Session, file_id: int):
@@ -63,9 +63,7 @@ def create_file_in_db(db: Session, file: schemas.FileCreate):
     """
     folder = get_folder_from_db(db, file.folder_id)
     uuid = file.uuid
-    filename = uuid.hex
-    if file.extension:
-        filename = f"{uuid.hex}.{file.extension}"
+    filename = f'{uuid.hex}'
     output_file = os.path.join(folder.path, filename)
 
     # File metadata
@@ -99,7 +97,8 @@ def get_file_summary_from_db(db: Session, file_summary_id: int):
     return db.get(FileSummary, file_summary_id)
 
 
-def create_file_summary_in_db(db: Session, file_summary: schemas.FileSummaryCreate):
+def create_file_summary_in_db(db: Session,
+                              file_summary: schemas.FileSummaryCreate):
     """Creates a new file summary in the database using generative AI.
 
     Args:

--- a/src/datastores/sql/models/file.py
+++ b/src/datastores/sql/models/file.py
@@ -134,9 +134,7 @@ class File(BaseModel):
     @hybrid_property
     def path(self):
         """Returns the full path of the file."""
-        filename = self.uuid.hex
-        if self.extension:
-            filename = f"{filename}.{self.extension}"
+        filename = f"{self.uuid.hex}"
         return os.path.join(self.folder.path, filename)
 
 


### PR DESCRIPTION
Remove file extensions when storing filenames on disk as the filename on disk is always a uuid. We only use the file extension in the display_name!