### PR TITLE
Include Original File Path in File Metadata

### DIFF
--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -138,6 +138,7 @@ class FileCreate(BaseModel):
     filename: str
     filesize: Optional[int] = None
     extension: Optional[str] = None
+    original_path: Optional[str] = None
     magic_text: Optional[str] = None
     magic_mime: Optional[str] = None
     data_type: Optional[str] = None
@@ -157,6 +158,7 @@ class FileResponse(BaseSchema):
     filename: str
     filesize: int
     extension: Optional[str] = None
+    original_path: Optional[str] = None
     magic_text: Optional[str] = None
     magic_mime: Optional[str] = None
     data_type: str
@@ -164,6 +166,7 @@ class FileResponse(BaseSchema):
     hash_sha1: Optional[str] = None
     hash_sha256: Optional[str] = None
     hash_ssdeep: Optional[str] = None
+
     user_id: int
     user: UserResponseCompact
     folder: Optional[FolderResponse]

--- a/src/mediator/mediator.py
+++ b/src/mediator/mediator.py
@@ -110,11 +110,13 @@ def process_successful_task(db, celery_task, db_task, celery_app):
         data_type = file_data.get("data_type")
         file_uuid = uuid.UUID(file_data.get("uuid"))
         _, file_extension = os.path.splitext(display_name)
+        original_path = file_data.get("original_path")
         new_file = schemas.FileCreate(
             display_name=display_name,
             uuid=file_uuid,
             filename=display_name,
             extension=file_extension.lstrip("."),
+            original_path=original_path,
             data_type=data_type,
             folder_id=workflow.folder.id,
             user_id=workflow.user.id,


### PR DESCRIPTION
This PR adds the `original_path` field to file metadata, allowing for the preservation and display of a file's original path within the system.

**Key changes:**

* **Schema update:** The `FileCreate` and `FileResponse` schemas now include the `original_path` field, which is optional and of type string.
* **Mediator update:** The `process_successful_task` function in the mediator now extracts the `original_path` from the file data and includes it when creating a new `FileCreate` object.

**Benefits:**

* **Improved context:** Provides users with more information about the origin of a file, which can be crucial for investigations and analysis.
* **Enhanced tracking:** Helps track files that may have been moved or renamed during processing, preserving their original location information.
