### PR TITLE
Change Logout Endpoint to POST

### DIFF
--- a/src/auth/common.py
+++ b/src/auth/common.py
@@ -366,7 +366,7 @@ async def csrf(
     return csrf_token_from_cookie
 
 
-@router.delete("/auth/logout")
+@router.post("/auth/logout")
 async def logout(response: Response):
     """Logs out the currently logged-in user by deleting the access token cookie.
 


### PR DESCRIPTION
### Summary:
Changed the HTTP method for the logout endpoint from DELETE to POST to adhere to best practices.

### Technical Details:
*   **Method Change:** The logout endpoint, located at `/auth/logout`, has been changed from a DELETE request to a POST request.  This aligns with standard web practices, where POST is typically used for actions that modify server state, such as logging a user out.