### PR TITLE
Change Logout Endpoint to DELETE

### DIFF
--- a/src/auth/common.py
+++ b/src/auth/common.py
@@ -366,7 +366,7 @@ async def csrf(
     return csrf_token_from_cookie
 
 
-@router.post("/auth/logout")
+@router.delete("/auth/logout")
 async def logout(response: Response):
     """Logs out the currently logged-in user by deleting the access token cookie.
 


### PR DESCRIPTION
### Summary
Changed the HTTP method for the logout endpoint from POST to DELETE.

### Technical Details:
* **Method Change:** The `logout` function in `src/auth/common.py` now uses the `@router.delete` decorator instead of `@router.post`.  This aligns the logout operation with the RESTful convention of using DELETE for removing resources.  Logging out effectively removes the user's session, which can be interpreted as deleting a resource.
* **No Functional Changes:**  The functionality of the logout endpoint remains unchanged.  The endpoint still deletes the access token cookie, effectively logging the user out.  Only the HTTP method used to access this functionality has been modified. This change improves the API's adherence to RESTful principles.