### PR TITLE
Support Google Workspace Domain Restriction and Public Access

### DIFF
--- a/settings_example.toml
+++ b/settings_example.toml
@@ -39,8 +39,17 @@ jwt_header_default_access_expire_minutes = 5  # 5 minutes
 client_id = ""
 client_secret = ""
 
+# Restrict logins from a Google Workspace domain.
+# Empty value = any domain, including gmail.com
+workspace_domain = ""
+
 # Allow only these users (email address) to access the server.
 allowlist = ["<REPLACE_WITH_USERNAME>@gmail.com"]
+
+# Allow anyone (who is authenitcated) to access the server.
+# Note: If a workspace_domain is set then the public_access is limited to that domain.
+# WARNING: This allows anyone to login to your server!
+public_access = false
 
 [ui]
 # data_types that will be rendered using unescaped HTML in a sandboxed iframe in the


### PR DESCRIPTION
### Summary:
This change introduces the ability to restrict logins to a specific Google Workspace domain and adds a public access option for simplified authentication.

### Technical Details:

* **Google Workspace Domain Restriction:**  Added a new configuration option, `workspace_domain`, in `settings_example.toml`.  This setting allows administrators to restrict logins to users within a specified Google Workspace domain.  If configured, the authentication flow will include the `hd` parameter (hosted domain) in the Google authorization redirect, ensuring only users from the designated domain can authenticate. This enhances security by limiting access to authorized organizational accounts.

* **Public Access Option:** Introduced a `public_access` boolean configuration option in `settings_example.toml`. When set to `true`, this option bypasses the `allowlist` check, granting access to any authenticated Google user (potentially restricted by the `workspace_domain` setting).  This simplifies access management when a broader audience needs access, eliminating the need to maintain an allowlist.  **WARNING:**  Enabling public access while `workspace_domain` is empty will allow *any* Google user to login.

* **Configuration Handling & Logic:**  The `src/auth/google.py` file has been updated to read and apply these new configuration options. The `login` function now dynamically includes the `hd` parameter if `workspace_domain` is configured. The `auth` function checks the user's hosted domain against the configured `workspace_domain` and grants or denies access accordingly. The `allowlist` check is only performed if `public_access` is `false`. This logic ensures a flexible and secure authentication process based on the provided configuration.