### PR TITLE
Extend JWT Access Token Expiration

### DIFF
--- a/settings_example.toml
+++ b/settings_example.toml
@@ -27,7 +27,7 @@ jwt_algorithm = "HS256"
 
 # UI token expiration in minutes.
 jwt_cookie_refresh_expire_minutes = 1440  # 24 hours
-jwt_cookie_access_expire_minutes = 5  # 5 minutes
+jwt_cookie_access_expire_minutes = 720  # 12 hours
 
 # API key token expiration in minutes, if not set by the user upon creation.
 jwt_header_default_refresh_expire_minutes = 10080  # 7 days


### PR DESCRIPTION
### Summary:
Increased the lifespan of JWT access tokens from 5 minutes to 12 hours.

### Technical Details:
* **Extended Default Token Lifespan:** The `jwt_cookie_access_expire_minutes` setting in `settings_example.toml` has been changed from `5` minutes to `720` minutes (12 hours).  This significantly extends the validity period of access tokens issued for UI interactions.
* **Impact on User Experience:**  This change improves the user experience by reducing the frequency of required logins. Users will now remain logged in for 12 hours before needing to re-authenticate, assuming no other invalidation events occur.
* **Security Considerations:** While extending token lifespan enhances usability, it's crucial to be aware of the potential security implications. Longer-lived tokens increase the window of vulnerability if a token is compromised.  This change should be balanced against the organization's security policies and risk tolerance.  Regularly reviewing and adjusting this setting is recommended.
* **Example Update:** The provided diff updates the `settings_example.toml` file. Ensure the corresponding `settings.toml` file (or your production settings file) is also updated to reflect this change if desired.