### PR TITLE
Improve Celery Metrics Exporter with Queue Length and Dynamic Labels

### DIFF
--- a/src/api/v1/metrics.py
+++ b/src/api/v1/metrics.py
@@ -81,10 +81,18 @@ def format_prometheus_data(prometheus_response: dict) -> list[dict]:
         Timestamps are in milliseconds.
     """
     formatted_series = []
+    metric_name_keys = ["task_name", "queue_name"]
 
     for result in prometheus_response["data"]["result"]:
         data_points = []
-        series_name = result["metric"].get("task_name", "sum")
+        series_name = next(
+            (
+                result["metric"].get(key)
+                for key in metric_name_keys
+                if result["metric"].get(key)
+            ),
+            "sum",
+        )
 
         for value in result["values"]:
             timestamp_ms = float(value[0]) * 1000  # Convert to milliseconds


### PR DESCRIPTION
### Summary:
This PR improves the Celery metrics exporter by adding a new metric for queue length and enabling dynamic labels for task metrics.

### Technical Details:
* **Queue Length Metric:** A new Prometheus Counter metric, `celery_queue_length`, has been added to track the number of messages in each Celery queue. This metric provides valuable insights into queue backlog and worker utilization.  A custom `QueueMetricsCollector` was implemented using `prometheus_client.core.CounterMetricFamily` to gather and expose this information, dynamically labeling each queue.

* **Dynamic Labels for Task Metrics:**  The existing task metrics (e.g., `celery_task_sent`, `celery_task_received`) now support dynamic labels. This change allows for more granular monitoring and filtering of task events.  The implementation allows "extra_labels" to be specified per metric if needed, increasing flexibility.  This allows filtering and grouping of metrics based on task specific attributes.

* **Code Cleanup and Simplification:**  Simplified several functions and removed redundant comments for improved readability.  Removed unused `get_hostname` and streamlined the event handling logic. The hostname logic remains available for potential future use if needed.

* **Removed Redundant Heartbeat Logging:**  Filtered out the "worker-heartbeat" events from the logs to reduce noise and focus on relevant task-related events. This prevents the logs from being flooded with heartbeat messages.  This improves the signal-to-noise ratio of the logs.