### PR TITLE
Default ordering by creation date for root and shared folders

### DIFF
--- a/src/datastores/sql/crud/folder.py
+++ b/src/datastores/sql/crud/folder.py
@@ -43,6 +43,7 @@ def get_root_folders_from_db(db: Session, current_user: User):
             UserRole.role == Role.OWNER,
             Folder.parent_id.is_(None),
         )
+        .order_by(Folder.created_at.desc())
         .all()
     )
 
@@ -93,6 +94,7 @@ def get_shared_folders_from_db(db: Session, current_user: User):
             ),
         )
         .filter(UserRole.id.is_(None))
+        .order_by(Folder.created_at.desc())
         .all()
     )
 


### PR DESCRIPTION
### Summary:
Added default ordering by descending creation date for retrieved root and shared folders.

### Technical Details:
*   **Database Query Modification:** The database queries in `src/datastores/sql/crud/folder.py` for retrieving root folders (`get_root_folders_from_db`) and shared folders (`get_shared_folders_from_db`) have been modified to include an `order_by` clause.  This clause sorts the results by the `created_at` timestamp in descending order (most recent first).
