### PR TITLE
Remove Cloud Provider Configuration and API endpoints

### DIFF
--- a/settings_example.toml
+++ b/settings_example.toml
@@ -57,12 +57,3 @@ public_access = false
 allowed_data_types_preview = [
     "openrelik:hayabusa:html_report"
 ]
-
-# Enable cloud features such as adding cloud disks.
-# This requires your OpenRelik installation to run on cloud VMs.
-[cloud.gcp]
-name = "gcp"
-display_name = "Google Cloud Platform"
-project_name = ""
-zone = ""
-enabled = false

--- a/src/api/v1/configs.py
+++ b/src/api/v1/configs.py
@@ -14,7 +14,7 @@
 
 from fastapi import APIRouter
 
-from config import config, get_active_cloud_provider, get_active_llms
+from config import config, get_active_llms
 
 
 router = APIRouter()
@@ -23,7 +23,6 @@ router = APIRouter()
 @router.get("/system/")
 def get_system_config():
     active_llms = get_active_llms()
-    active_cloud = get_active_cloud_provider()
 
     # Data types that will be allowed to be returned as unescaped HTML for use in
     # sandboxed iframe preview.
@@ -33,6 +32,5 @@ def get_system_config():
 
     return {
         "active_llms": active_llms,
-        "active_cloud": active_cloud,
         "allowed_data_types_preview": allowed_data_types_preview,
     }

--- a/src/config.py
+++ b/src/config.py
@@ -18,7 +18,6 @@ import sys
 
 from fastapi import HTTPException
 
-from lib.constants import cloud_provider_data_type_mapping
 from openrelik_ai_common.providers import manager
 
 
@@ -41,24 +40,6 @@ def get_config() -> dict:
     with open(settings_file, "rb") as fh:
         config = tomllib.load(fh)
     return config
-
-
-def get_active_cloud_provider() -> dict:
-    """Get the active cloud provider from config."""
-    clouds = config.get("cloud", [])
-    if len(clouds) > 1:
-        raise HTTPException(
-            status_code=500,
-            detail="More than one cloud enabled, you can only run on one cloud at a time",
-        )
-    active_cloud = [
-        cloud_provider
-        for cloud_provider in clouds.values()
-        if cloud_provider.get("enabled", False)
-    ]
-
-    return active_cloud[0] if active_cloud else {}
-
 
 def get_active_llms() -> dict:
     """Get active LLM providers from the LLM manager."""

--- a/src/lib/constants.py
+++ b/src/lib/constants.py
@@ -11,9 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-cloud_provider_data_type_mapping = {
-    "gcp": "cloud:gcp:disk",
-    "aws": "cloud:aws:disk",
-    "azure": "cloud:azure:disk",
-}

--- a/src/tests/api/v1/configs_test.py
+++ b/src/tests/api/v1/configs_test.py
@@ -18,18 +18,13 @@
 def test_get_system_config(fastapi_test_client, mocker):
     """Test the get_system_config endpoint."""
     mock_get_active_llms = mocker.patch("api.v1.configs.get_active_llms")
-    mock_get_active_cloud = mocker.patch("api.v1.configs.get_active_cloud_provider")
 
     mock_active_llms = [{"name": "test_llm"}]
     mock_get_active_llms.return_value = mock_active_llms
 
-    mock_active_cloud = {"name": "test_cloud"}
-    mock_get_active_cloud.return_value = mock_active_cloud
-
     response = fastapi_test_client.get("/configs/system/")
     assert response.status_code == 200
     assert response.json()["active_llms"] == mock_active_llms
-    assert response.json()["active_cloud"] == mock_active_cloud
     assert response.json()["allowed_data_types_preview"] == [
         "openrelik:hayabusa:html_report"
     ]

--- a/src/tests/api/v1/conftest.py
+++ b/src/tests/api/v1/conftest.py
@@ -98,54 +98,6 @@ def task_response(user_db_model, workflow_schema_mock) -> schemas.TaskResponse:
     return mock_task_response
 
 
-@pytest.fixture
-def file_response_cloud_disk_File(
-    tmp_path, user_db_model, folder_db_model
-) -> schemas.FileResponse:
-    """Fixture for a mock FileResponse object."""
-    file_id = 1
-    display_name = "test_disk.json"
-    path = os.path.join(tmp_path, display_name)
-
-    with open(path, "w") as f:
-        f.write("Dummy file content")
-
-    file_size = os.path.getsize(path)
-
-    user_response_compact = schemas.UserResponseCompact.model_validate(
-        user_db_model, from_attributes=True
-    )
-    file_data = {
-        "id": file_id,
-        "display_name": display_name,
-        "description": "Test file description",
-        "uuid": uuid.UUID("3fa85f64-5717-4562-b3fc-2c963f66afa6"),
-        "filename": "test_disk",
-        "filesize": file_size,
-        "extension": "json",
-        "original_path": path,
-        "magic_text": "openrelik:test_cloud_provider:disk",
-        "magic_mime": "openrelik:test_cloud_provider:disk",
-        "data_type": "openrelik:test_cloud_provider:disk",
-        "hash_md5": "test_md5",
-        "hash_sha1": "test_sha1",
-        "hash_sha256": "test_sha256",
-        "hash_ssdeep": "test_ssdeep",
-        "user_id": 1,
-        "user": user_response_compact,
-        "created_at": None,
-        "updated_at": None,
-        "deleted_at": None,
-        "folder": folder_db_model,
-        "source_file": None,
-        "workflows": [],
-        "summaries": [],
-        "reports": [],
-        "is_deleted": False,
-    }
-    mock_file_response = schemas.FileResponse(**file_data)
-    return mock_file_response
-
 
 @pytest.fixture
 def file_response(tmp_path, user_db_model, folder_db_model) -> schemas.FileResponse:

--- a/src/tests/api/v1/files_test.py
+++ b/src/tests/api/v1/files_test.py
@@ -136,35 +136,6 @@ async def test_upload_files(
     assert response.json() == file_response.model_dump()
 
 
-@pytest.mark.asyncio
-async def test_create_cloud_disk_file(
-    fastapi_async_test_client, mocker, file_response_cloud_disk_File, folder_db_model
-):
-    """Test the create_cloud_disk_file endpoint."""
-    mock_config = mocker.patch("datastores.sql.models.folder.get_config")
-    mock_active_cloud = {"name": "test_cloud"}
-    mock_get_active_cloud = mocker.patch("api.v1.configs.get_active_cloud_provider")
-    mock_get_active_cloud.return_value = mock_active_cloud
-    mock_get_folder_from_db = mocker.patch("api.v1.files.get_folder_from_db")
-    mock_get_folder_from_db.return_value = folder_db_model
-    mock_get_active_cloud_provider = mocker.patch(
-        "api.v1.files.get_active_cloud_provider"
-    )
-    mock_get_active_cloud_provider.return_value = {"name": "test_cloud_provider"}
-    file_content = "Mocked file content"
-    mock_open = mocker.mock_open(read_data=file_content)
-    mocker.patch("builtins.open", mock_open)
-    mock_create_file_in_db = mocker.patch("api.v1.files.create_file_in_db")
-    mock_create_file_in_db.return_value = file_response_cloud_disk_File
-    mock_background_tasks_add_task = mocker.patch(
-        "api.v1.files.BackgroundTasks.add_task"
-    )
-    request = {"disk_name": "test_disk", "folder_id": folder_db_model.id}
-
-    response = await fastapi_async_test_client.post("/files/cloud", json=request)
-    assert response.status_code == 201
-    assert response.json() == file_response_cloud_disk_File.model_dump(mode="json")
-
 
 def test_get_workflows_empty(fastapi_test_client, mocker):
     """Test the get_workflows endpoint."""


### PR DESCRIPTION
### Summary:
Removes cloud provider configuration settings and related API endpoints. This functionality is not used, and was put in place to an anticipated feature around cloud disks. The design has changed and this is not needed anymore.

### Technical Details:
*   Removes cloud provider configuration options from `settings_example.toml`. This simplifies configuration by removing unused settings.
*   Removes the `get_active_cloud_provider` function from `src/config.py`. This function is no longer needed.
*   Removes related code from the `/configs/system/` API endpoint in `src/api/v1/configs.py`. Specifically, the retrieval of the active cloud provider is removed, streamlining the system configuration endpoint.
*   Removes the `/files/cloud` API endpoint and related code from `src/api/v1/files.py`. This includes the `create_cloud_disk_file` function and references to cloud provider data type mappings.
*   Removes `cloud_provider_data_type_mapping` from `src/lib/constants.py`.  This mapping is no longer used since the cloud disk file creation functionality has been removed.
*   Removes tests related to cloud provider configurations from `src/tests/api/v1/configs_test.py`. This ensures that the test suite reflects the removal of the cloud provider configuration.
*   Removes the `file_response_cloud_disk_File` fixture and test from `src/tests/api/v1/files_test.py` since cloud disk file functionality has been removed.