### PR TITLE
Add LLM failure state to summary

### DIFF
--- a/src/lib/llm_summary.py
+++ b/src/lib/llm_summary.py
@@ -94,13 +94,17 @@ def generate_summary(
 
     start_time = datetime.now()
 
-    details = llm.generate_file_analysis(
-        prompt=ANALYSIS_PROMPT.format(
-            magic_text=file.magic_text, filename=file.display_name
-        ),
-        file_content=file_content,
-    )
-    summary = llm.generate(prompt=SUMMARY_PROMPT.format(analysis_details=details))
+    try:
+        details = llm.generate_file_analysis(
+            prompt=ANALYSIS_PROMPT.format(
+                magic_text=file.magic_text, filename=file.display_name
+            ),
+            file_content=file_content,
+        )
+        summary = llm.generate(prompt=SUMMARY_PROMPT.format(analysis_details=details))
+    # Broad exception handling because we don't know what the AI provider will raise.
+    except Exception as e:
+        summary = f"There was a problem with the analysis: {e}"
 
     end_time = datetime.now()
     duration = end_time - start_time


### PR DESCRIPTION
## Note
I know this is a broad exception catch - it's a bit tricky because the different LLM providers crash in different ways. I'm planning on reworking this feature in the near future, so adding this check now so we don't crash and creates broken summary objects.

### Summary
Adds try-except block to handle exceptions from LLM providers

### Technical Details:
*   **Error Handling:** A `try-except` block now wraps the LLM analysis and summarization calls in `src/lib/llm_summary.py`. This addresses potential issues arising from unpredictable exceptions raised by various LLM providers.
*   **Fallback Mechanism:** If an exception occurs during LLM processing, the `summary` is now set to a descriptive error message indicating the problem. This change prevents the application from crashing and provides informative feedback to the user. The error message includes the specific exception encountered.