### PR TITLE
Add CLI command to create user API keys

### DIFF
--- a/src/admin.py
+++ b/src/admin.py
@@ -139,8 +139,7 @@ def change_password(
 @app.command()
 def create_api_key(
     username: str = typer.Argument(None, help="User to create API key for."),
-    key_name: str = typer.Option(
-        None, "--key-name", "-n", help="Name for the API key."),
+    key_name: str = typer.Option(..., "--key-name", "-n", help="Name for the API key."),
     key_description: Optional[str] = typer.Option(
         None, "--description", "-d", help="Description for the API key (optional)."
     ),
@@ -148,11 +147,7 @@ def create_api_key(
     """Create an API key for a user."""
     db = database.SessionLocal()
 
-    # Check for existing user *before* potentially prompting
-    if not username and get_user_by_username_from_db(db, username):
-        print("[bold red]Error: User already exists.[/bold red]")
-        raise typer.Exit(code=1)
-
+    # If username is not provided, prompt for it
     if not username:
         username = Prompt.ask("[bold blue]Enter username[/]")
 


### PR DESCRIPTION
### Summary:
Introduced a new command-line interface (CLI) command to create API keys for users.

```
admin.py create-api-key <USERNAME> --key-name "<KEY NAME>"
```

### Technical Details:
*   **New CLI Command:** Added a `create_api_key` command to the `src/admin.py` script using the `typer` library. This command allows administrators to create API keys for existing users directly from the command line. The command requires a username and key name and accepts optional argument for the key description.
*   **API Key Generation:** The command retrieves user details, generates a refresh token, and stores the associated information (JTI, expiration) along with the user ID and provided metadata in the database using the `create_user_api_key_in_db` function.
*   **Error Handling:** Checks for the existence of the user before proceeding and provides informative error messages if the user is not found.
*   **Token Generation Dependency:** Leverages `create_jwt_token` and `validate_jwt_token` functions from `auth.common` to generate and validate refresh tokens, using the JTI (JWT ID) as a unique identifier for the API key.
*   **Configuration Dependency:** Imports `get_config` to retrieve token expiration times.
