### PR TITLE
Add health check endpoint

### DIFF
--- a/src/healthz.py
+++ b/src/healthz.py
@@ -32,7 +32,7 @@ def _check_posgresql_connection():
     """
     try:
         db = database.SessionLocal()
-        db.execute(text('SELECT foo'))
+        db.execute(text('SELECT 1'))
         return "Ok"
     except Exception:  # pylint: disable=broad-except
         return "Database connection error"

--- a/src/healthz.py
+++ b/src/healthz.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import redis
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import text
+
+from datastores.sql import database
+
+router = APIRouter()
+
+def _check_posgresql_connection():
+    """Check the connection to the PostgreSQL database.
+
+    This function uses a broad exception to catch all errors but not expose them to the
+    user as this is a health check and it is unauthenticated.
+
+    Returns:
+        str: "Ok" if the connection is successful, otherwise an error message
+    """
+    try:
+        db = database.SessionLocal()
+        db.execute(text('SELECT 1'))
+        return "Ok"
+    except Exception:  # pylint: disable=broad-except
+        return "Database connection error"
+
+def _check_redis_connection(redis_url="redis://localhost:6379"):
+    """Check the connection to the Redis database.
+
+    This function uses a broad exception to catch all errors but not expose them to the
+    user as this is a health check and it is unauthenticated.
+
+    Returns:
+        str: "Ok" if the connection is successful, otherwise an error message
+    """
+    try:
+        parsed_url = urlparse(redis_url)
+        host = parsed_url.hostname
+        port = parsed_url.port or 6379  # Default to 6379 if no port is specified
+        redis_db = redis.Redis(host=host, port=port)
+        redis_db.ping()
+        return "Ok"
+    except Exception:  # pylint: disable=broad-except
+        return f"Redis connection error"
+
+
+@router.get("/healthz")
+def healthz() -> dict:
+    """Health check endpoint.
+
+    This endpoint checks the connection to critical services. If any of the services
+    are not reachable, it will return a 500 status code with information on which
+    services that are not reachable.
+
+    Returns:
+        dict: A dictionary with the status of the services
+
+    Raises:
+        HTTPException (500): If any of the services are not reachable
+    """
+    status = {
+        "posgresql": _check_posgresql_connection(),
+        "redis": _check_redis_connection(),
+    }
+    # If any of the services are not reachable, return a 500 status code with the
+    # status of the services that are not reachable.
+    if not all(value == "Ok" for value in status.values()):
+        raise HTTPException(status_code=500, detail=status)
+
+    # If all services are reachable, return a 200 status code with the status of the
+    # individual services.
+    return status
+
+

--- a/src/healthz.py
+++ b/src/healthz.py
@@ -43,6 +43,9 @@ def _check_redis_connection(redis_url: str) -> str:
     This function uses a broad exception to catch all errors but not expose them to the
     user as this is a health check and it is unauthenticated.
 
+    Args:
+        redis_url (str): The URL to the Redis database
+
     Returns:
         str: "Ok" if the connection is successful, otherwise an error message
     """

--- a/src/healthz.py
+++ b/src/healthz.py
@@ -21,7 +21,7 @@ from datastores.sql import database
 
 router = APIRouter()
 
-def _check_posgresql_connection():
+def _check_posgresql_connection() -> str:
     """Check the connection to the PostgreSQL database.
 
     This function uses a broad exception to catch all errors but not expose them to the
@@ -37,7 +37,7 @@ def _check_posgresql_connection():
     except Exception:  # pylint: disable=broad-except
         return "Database connection error"
 
-def _check_redis_connection(redis_url="redis://localhost:6379"):
+def _check_redis_connection(redis_url: str) -> str:
     """Check the connection to the Redis database.
 
     This function uses a broad exception to catch all errors but not expose them to the

--- a/src/healthz.py
+++ b/src/healthz.py
@@ -32,7 +32,7 @@ def _check_posgresql_connection():
     """
     try:
         db = database.SessionLocal()
-        db.execute(text('SELECT 1'))
+        db.execute(text('SELECT foo'))
         return "Ok"
     except Exception:  # pylint: disable=broad-except
         return "Database connection error"

--- a/src/main.py
+++ b/src/main.py
@@ -32,6 +32,7 @@ from api.v1 import workflows as workflows_v1
 from auth import common as common_auth
 from auth import google as google_auth
 from auth import local as local_auth
+from healthz import router as healthz_router
 from config import config
 from datastores.sql.crud.group import (
     add_user_to_group,
@@ -121,6 +122,7 @@ api_v1.add_middleware(
 app.include_router(common_auth.router)
 app.include_router(local_auth.router)
 app.include_router(google_auth.router)
+app.include_router(healthz_router)
 
 # Routes
 api_v1.include_router(

--- a/src/tests/healthz_test.py
+++ b/src/tests/healthz_test.py
@@ -1,0 +1,50 @@
+import pytest
+from fastapi import HTTPException
+
+import healthz
+
+
+def test_healthz_success(mocker):
+    """Test healthz endpoint when all services are reachable."""
+    mocker.patch("healthz._check_posgresql_connection", return_value="Ok")
+    mocker.patch("healthz._check_redis_connection", return_value="Ok")
+
+    response = healthz.healthz()
+
+    assert response == {"posgresql": "Ok", "redis": "Ok"}
+
+
+def test_healthz_postgresql_failure(mocker):
+    """Test healthz endpoint when PostgreSQL connection fails."""
+    mocker.patch("healthz._check_posgresql_connection", return_value="Database connection error")
+    mocker.patch("healthz._check_redis_connection", return_value="Ok")
+
+    with pytest.raises(HTTPException) as exc_info:
+        healthz.healthz()
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {"posgresql": "Database connection error", "redis": "Ok"}
+
+
+def test_healthz_redis_failure(mocker):
+    """Test healthz endpoint when Redis connection fails."""
+    mocker.patch("healthz._check_posgresql_connection", return_value="Ok")
+    mocker.patch("healthz._check_redis_connection", return_value="Redis connection error")
+
+    with pytest.raises(HTTPException) as exc_info:
+        healthz.healthz()
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {"posgresql": "Ok", "redis": "Redis connection error"}
+
+
+def test_healthz_both_failures(mocker):
+    """Test healthz endpoint when both PostgreSQL and Redis connections fail."""
+    mocker.patch("healthz._check_posgresql_connection", return_value="Database connection error")
+    mocker.patch("healthz._check_redis_connection", return_value="Redis connection error")
+
+    with pytest.raises(HTTPException) as exc_info:
+        healthz.healthz()
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {"posgresql": "Database connection error", "redis": "Redis connection error"}

--- a/src/tests/healthz_test.py
+++ b/src/tests/healthz_test.py
@@ -1,3 +1,16 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import pytest
 from fastapi import HTTPException
 


### PR DESCRIPTION
### Summary
Introduces a `/healthz` endpoint to monitor the service's health status by verifying connections to PostgreSQL and Redis.

Details are kept high level to not expose sensitive information. This endpoint is unauthenticated.

Tests OK, returns a HTTP 200:
```
{"posgresql":"Ok","redis":"Ok"}
```

Tests fail, returns a HTTP 500 error with details:
```
{"detail":{"posgresql":"Database connection error","redis":"Ok"}}
```

### Technical Details:
*   **New `healthz.py` file:** Adds a new file `src/healthz.py` that defines a `/healthz` endpoint. This endpoint checks connectivity to both the PostgreSQL database and the Redis instance. It returns a 200 status code if both connections are healthy, and a 500 status code with details on connection failures if either service is unreachable. The checks handle exceptions internally to avoid exposing sensitive error information.
*   **Integration in `main.py`:** The `healthz_router` from `src/healthz.py` is included in the main application in `src/main.py`, making the `/healthz` endpoint accessible.
*   **New `healthz_test.py` file:** Includes tests in `src/tests/healthz_test.py` for the new health check endpoint.  The tests verify correct behavior when both services are healthy and when either or both services are unreachable.  Mocks are employed to simulate the database and Redis connections.


Fixes #63 