### PR TITLE
remove newlines and spaces returned in token

### DIFF
--- a/src/admin.py
+++ b/src/admin.py
@@ -178,6 +178,9 @@ def create_api_key(
     )
     create_user_api_key_in_db(db, new_api_key)
 
+    # Remove spaces and newlines returned in token
+    refresh_token = refresh_token.replace(" ", "").replace("\n", "")
+    
     print(refresh_token)
 
 @app.command()


### PR DESCRIPTION
after testing, the keys returned with the CLI weren't working, while the ones in the web UI were. i manually removed the spaces and newlines from the keys returned via the CLI and tested against the API and they worked fine. adding a line to clean up the token before printing.