### PR TITLE
Expand AI summary generation permissions

### DIFF
--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -366,7 +366,7 @@ def get_file_summary(
 
 
 @router.post("/{file_id}/summaries")
-@require_access(allowed_roles=[Role.EDITOR, Role.OWNER])
+@require_access(allowed_roles=[Role.VIEWER, Role.EDITOR, Role.OWNER])
 def generate_file_summary(
     file_id: int,
     background_tasks: BackgroundTasks,


### PR DESCRIPTION
### Summary
Permits viewers to generate file summaries.

### Technical Details:
*   The `generate_file_summary` endpoint in `src/api/v1/files.py` now allows users with the `VIEWER` role to trigger file summary generation. Previously, only `EDITOR` and `OWNER` roles were authorized. This change broadens access to this functionality.