### PR TITLE
Add endpoint to retrieve all accessible folders

### DIFF
--- a/src/datastores/sql/crud/folder.py
+++ b/src/datastores/sql/crud/folder.py
@@ -102,7 +102,7 @@ def get_all_folders_from_db(db: Session, current_user: User, search_term: str | 
     Retrieves accessible folders with conditional logic based on search term.
 
     - If search_term is NOT provided (Default View):
-        Returns user's pwned root folders plus all directly shared folders
+        Returns user's owned root folders plus all directly shared folders
         (root and subfolders where share is explicit). Uses non-recursive logic.
     - If search_term IS provided (Recursive Search Mode):
         Uses resursive logic to find ALL accessible folders (direct/inherited,

--- a/src/datastores/sql/crud/folder.py
+++ b/src/datastores/sql/crud/folder.py
@@ -15,8 +15,8 @@
 import os
 import uuid
 
-from sqlalchemy.orm import Session
-from sqlalchemy.sql import and_
+from sqlalchemy import and_, select, union
+from sqlalchemy.orm import Session, aliased
 
 from api.v1 import schemas
 from datastores.sql.models.folder import Folder
@@ -82,9 +82,7 @@ def get_shared_folders_from_db(db: Session, current_user: User):
     return (
         db.query(Folder)
         .select_from(shared_folders)  # Use select_from to make the join explicit
-        .join(
-            Folder, Folder.id == shared_folders.c.id
-        )  # Specify the join condition here
+        .join(Folder, Folder.id == shared_folders.c.id)  # Specify the join condition here
         .outerjoin(
             UserRole,
             and_(
@@ -99,6 +97,126 @@ def get_shared_folders_from_db(db: Session, current_user: User):
     )
 
 
+def get_all_folders_from_db(db: Session, current_user: User, search_term: str | None = None):
+    """
+    Retrieves accessible folders with conditional logic based on search term.
+
+    - If search_term is NOT provided (Default View):
+        Returns user's pwned root folders plus all directly shared folders
+        (root and subfolders where share is explicit). Uses non-recursive logic.
+    - If search_term IS provided (Recursive Search Mode):
+        Uses resursive logic to find ALL accessible folders (direct/inherited,
+        including root folders), and filters them by search term (case-insensitive).
+
+    Args:
+        db (Session): database session
+        current_user (User): current user
+        search_term (str | None, optional): Term to filter folder names by
+
+    Returns:
+        list[Folder]: List of folders based on the mode, ordered by creation date desc.
+    """
+
+    final_query = None
+
+    if search_term:
+        # --- Search Mode: Recursive CTE for ALL accessible folders (Root + Subfolders) ---
+
+        # Step 1: Find IDs of Folders with DIRECT Access (Anchor Folders)
+        owned_anchor_ids = (
+            select(Folder.id)
+            .join(UserRole)
+            .filter(UserRole.user_id == current_user.id, UserRole.role == Role.OWNER)
+        )
+        direct_shared_anchor_ids = (
+            select(Folder.id)
+            .join(UserRole)
+            .filter(UserRole.user_id == current_user.id, UserRole.role != Role.OWNER)
+        )
+        group_shared_anchor_ids = (
+            select(Folder.id)
+            .join(GroupRole)
+            .join(Group)
+            .filter(Group.users.any(id=current_user.id))
+        )
+
+        direct_access_folder_ids_query = union(
+            owned_anchor_ids, direct_shared_anchor_ids, group_shared_anchor_ids
+        )
+
+        # Step 2: Define the Recursive CTE
+        accessible_folders_cte = (
+            select(Folder.id.label("id"))
+            .filter(Folder.id.in_(direct_access_folder_ids_query))
+            .cte(name="accessible_folders", recursive=True)
+        )
+        cte_alias = aliased(accessible_folders_cte, name="cte_alias")
+        folder_alias = aliased(Folder, name="folder_alias")
+        recursive_part = select(folder_alias.id).join(
+            cte_alias, folder_alias.parent_id == cte_alias.c.id
+        )
+        accessible_folders_cte = accessible_folders_cte.union_all(recursive_part)
+
+        # Step 3: Query Folders using the CTE and Apply Filters
+        # Join Folder with CTE results to get only accessible folders
+        final_query = db.query(Folder).join(
+            accessible_folders_cte, Folder.id == accessible_folders_cte.c.id
+        )
+
+        # Apply Search Filter (mandatory in this branch)
+        search_pattern = f"%{search_term}%"
+        final_query = final_query.filter(Folder.display_name.ilike(search_pattern))
+
+    else:
+        # --- Default View: Non-Recursive - Owned Roots + Direct Shares ---
+
+        # Query for root folders owned by the user
+        owned_root_folders_query = (
+            db.query(Folder)
+            .join(UserRole, UserRole.folder_id == Folder.id)
+            .filter(
+                UserRole.user_id == current_user.id,
+                UserRole.role == Role.OWNER,
+                Folder.parent_id.is_(None),  # Owned ROOT only for default view
+            )
+        )
+        # Query for folders directly shared (not owned)
+        user_shared_ids = (
+            db.query(Folder.id.label("id"))
+            .join(UserRole, UserRole.folder_id == Folder.id)
+            .filter(
+                UserRole.user_id == current_user.id,
+                UserRole.role != Role.OWNER,
+            )
+        )
+        group_shared_ids = (
+            db.query(Folder.id.label("id"))
+            .join(GroupRole, GroupRole.folder_id == Folder.id)
+            .join(Group, Group.id == GroupRole.group_id)
+            .filter(Group.users.any(id=current_user.id))
+        )
+        potentially_shared_folder_ids = user_shared_ids.union(group_shared_ids).subquery()
+        shared_folders_query = (
+            db.query(Folder)
+            .select_from(potentially_shared_folder_ids)
+            .join(Folder, Folder.id == potentially_shared_folder_ids.c.id)
+            .outerjoin(
+                UserRole,
+                and_(
+                    UserRole.folder_id == Folder.id,
+                    UserRole.user_id == current_user.id,
+                    UserRole.role == Role.OWNER,
+                ),
+            )
+            .filter(UserRole.id.is_(None))
+        )
+        # Combine owned roots and direct shares using UNION for the default view
+        final_query = owned_root_folders_query.union(shared_folders_query)
+
+    # --- Execute the selected query ---
+    return final_query.order_by(Folder.created_at.desc()).all()
+
+
 def get_subfolders_from_db(db: Session, parent_folder_id: str):
     """Get all folders in a folder
 
@@ -109,12 +227,7 @@ def get_subfolders_from_db(db: Session, parent_folder_id: str):
     Returns:
         list: list of folders
     """
-    return (
-        db.query(Folder)
-        .filter_by(parent_id=parent_folder_id)
-        .order_by(Folder.id.desc())
-        .all()
-    )
+    return db.query(Folder).filter_by(parent_id=parent_folder_id).order_by(Folder.id.desc()).all()
 
 
 def get_folder_from_db(db: Session, folder_id: int):


### PR DESCRIPTION
### Summary
Adds a new API endpoint to retrieve all folders accessible to a user, including a search function.

### Technical Details:
*   **API Endpoint:** A new GET endpoint `/api/v1/folders/all/` is added to `src/api/v1/folders.py`. This endpoint retrieves all folders accessible to the current user.
*   **Search Functionality:** The endpoint includes an optional query parameter `q` that allows users to search folders by display name.
*   **Database Logic:** The `get_all_folders_from_db` function in `src/datastores/sql/crud/folder.py` fetches accessible folders.
    *   If a search term is provided, the function uses a recursive CTE to find all accessible folders (direct/inherited) and filters them by the search term (case-insensitive).
    *   If no search term is provided, the function returns the user's owned root folders and all directly shared folders (root and subfolders), using non-recursive logic.
*   **Security:** The endpoint uses the `get_current_active_user` dependency to authenticate the user.
*   **Return Value:** The endpoint returns a list of `schemas.FolderResponseCompact` objects.