### PR TITLE
Add workflow name generation endpoint

### DIFF
--- a/src/api/v1/configs.py
+++ b/src/api/v1/configs.py
@@ -16,7 +16,6 @@ from fastapi import APIRouter
 
 from config import config, get_active_llms
 
-
 router = APIRouter()
 
 
@@ -26,9 +25,7 @@ def get_system_config():
 
     # Data types that will be allowed to be returned as unescaped HTML for use in
     # sandboxed iframe preview.
-    allowed_data_types_preview = config.get("ui", {}).get(
-        "allowed_data_types_preview", []
-    )
+    allowed_data_types_preview = config.get("ui", {}).get("allowed_data_types_preview", [])
 
     return {
         "active_llms": active_llms,

--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, field_serializer
-
-from datetime import datetime
-from typing import Optional, List
 
 
 def custom_uuid_encoder(uuid_object):
@@ -168,6 +167,7 @@ class FolderResponse(BaseSchema):
 class FolderResponseCompact(BaseSchema):
     display_name: str
     user: UserResponseCompact
+    workflows: List["WorkflowResponseCompact"]
     selectable: Optional[bool] = False
 
 
@@ -326,6 +326,10 @@ class WorkflowResponse(BaseSchema):
     folder: Optional["WorkflowFolder"]
 
 
+class WorkflowResponseCompact(BaseModel):
+    id: int
+
+
 class WorkflowStatusResponse(BaseSchema):
     tasks: Optional[List["TaskResponse"]]
 
@@ -358,6 +362,10 @@ class WorkflowTemplateResponse(BaseSchema):
     description: Optional[str] = None
     spec_json: str
     user_id: int
+
+
+class WorkflowGeneratedNameResponse(BaseModel):
+    generated_name: str
 
 
 class Task(BaseSchema):


### PR DESCRIPTION
### Summary:
Adds an API endpoint to automatically generate a descriptive name for a workflow using a language model.

This is used in the frontend to generate a workflow name based on the task list and input files. It is only triggered from the frontend when the workflow name is unchanged by the user (i.e. Untitled workflow).

### Technical Details:
*   **New API Endpoint:** Introduced a new GET endpoint, `GET /folders/{folder_id}/workflows/{workflow_id}/generate_name/`, that generates a name for a workflow. The name is derived from the workflow's specification (JSON) and the names of the input files.
*   **Name Generation Logic:** The endpoint uses a language model (LLM) to create a concise and descriptive name. The prompt provided to the LLM includes the workflow's spec (with `task_config` removed for brevity) and the filenames with their MIME types.  The `task_config` is removed to reduce the size of the request to the LLM.
*   **LLM Integration:** The endpoint retrieves the active LLM configuration and uses the `openrelik_ai_common` library to interface with the LLM provider.  If no active LLM is configured, the endpoint returns a `503 Service Unavailable` error.
*   **Response Format:** The endpoint returns a `WorkflowGeneratedNameResponse` object, which contains the generated name in the `generated_name` field.
*   **Schema Addition**: Introduced `WorkflowGeneratedNameResponse` in `src/api/v1/schemas.py`.
*   **Configuration Update**: Modified `get_system_config` in `src/api/v1/configs.py` to improve readability by removing an unnecessary line break.
*   **UI Integration Preparation**: Added `workflows: List["WorkflowResponseCompact"]` to the `FolderResponseCompact` schema to prepare the API for easier integration with the UI.
*   **Security:** The endpoint is protected by `require_access` decorator, restricting access to users with `EDITOR` or `OWNER` roles.