### PR TITLE
Add Group Management Commands to Admin CLI

### DIFF
--- a/src/admin.py
+++ b/src/admin.py
@@ -29,6 +29,11 @@ from api.v1 import schemas
 from auth.common import create_jwt_token, validate_jwt_token
 from config import get_config
 from datastores.sql import database
+from datastores.sql.crud.group import (
+    create_group_in_db,
+    get_group_by_name_from_db,
+    get_groups_from_db,
+)
 from datastores.sql.crud.user import (
     create_user_api_key_in_db,
     create_user_in_db,
@@ -589,6 +594,78 @@ def delete_workflow_template(
         print(f"Workflow template with ID {template_id} has been deleted.")
     except ValueError as e:
         print(f"Error: {e}")
+
+
+@app.command()
+def list_groups():
+    """Lists all groups in a table."""
+    with database.SessionLocal() as db:
+        groups = get_groups_from_db(db)
+        table = Table(title="List of Groups")
+        table.add_column("Group Name", style="green")
+        table.add_column("Description", style="magenta")
+        table.add_column("Number of users", style="yellow")
+        table.add_column("Created")
+        for group in groups:
+            table.add_row(
+                group.name, group.description, str(len(group.users)), str(group.created_at)
+            )
+        print(table)
+
+
+@app.command()
+def create_group(
+    group_name: str = typer.Argument(..., help="Name of the group to create."),
+    description: str = typer.Option("", "--description", "-d", help="Description of the group."),
+):
+    """Creates a new group."""
+    with database.SessionLocal() as db:
+        group = get_group_by_name_from_db(db, group_name)
+        if group:
+            print(f"Group '{group_name}' already exists.")
+            raise typer.Exit(code=1)
+        new_group = schemas.GroupCreate(name=group_name, description=description)
+        create_group_in_db(db, new_group)
+        print(f"Group '{group_name}' created")
+
+
+@app.command()
+def rename_group(
+    old_group_name: str = typer.Argument(..., help="Old name of the group."),
+    new_group_name: str = typer.Argument(..., help="New name of the group."),
+):
+    """Renames an existing group."""
+    with database.SessionLocal() as db:
+        group = get_group_by_name_from_db(db, old_group_name)
+        if not group:
+            print(f"Group '{old_group_name}' not found.")
+            raise typer.Exit(code=1)
+
+        group.name = new_group_name
+        db.commit()
+        print(f"Group '{old_group_name}' renamed to '{new_group_name}'.")
+
+
+@app.command()
+def add_user_to_group(
+    group_name: str = typer.Argument(..., help="Name of the group."),
+    username: str = typer.Argument(..., help="Username of the user to add."),
+):
+    """Adds a user to a group."""
+    with database.SessionLocal() as db:
+        group = get_group_by_name_from_db(db, group_name)
+        if not group:
+            print(f"Group '{group_name}' not found.")
+            raise typer.Exit(code=1)
+
+        user = get_user_by_username_from_db(db, username)
+        if not user:
+            print(f"User '{username}' not found.")
+            raise typer.Exit(code=1)
+
+        group.users.append(user)
+        db.commit()
+        print(f"User '{username}' added to group '{group_name}'.")
 
 
 if __name__ == "__main__":

--- a/src/datastores/sql/models/group.py
+++ b/src/datastores/sql/models/group.py
@@ -47,12 +47,8 @@ class Group(BaseModel):
     """
 
     name: Mapped[str] = mapped_column(UnicodeText, unique=True, index=True)
-    description: Mapped[Optional[str]] = mapped_column(
-        UnicodeText, unique=False, index=False
-    )
-    uuid: Mapped[uuid_module.UUID] = mapped_column(
-        UUID(as_uuid=True), unique=True, index=True
-    )
+    description: Mapped[Optional[str]] = mapped_column(UnicodeText, unique=False, index=False)
+    uuid: Mapped[uuid_module.UUID] = mapped_column(UUID(as_uuid=True), unique=True, index=True)
     users: Mapped[List["User"]] = relationship(
         secondary=group_user_association_table,
         back_populates="groups",
@@ -72,9 +68,7 @@ class GroupRole(BaseModel):
     # Relationships
     group_id: Mapped[int] = mapped_column(ForeignKey("group.id"))
     group: Mapped["Group"] = relationship(back_populates="group_roles")
-    folder_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("folder.id"), nullable=True
-    )
+    folder_id: Mapped[Optional[int]] = mapped_column(ForeignKey("folder.id"), nullable=True)
     folder: Mapped[Optional["Folder"]] = relationship(back_populates="group_roles")
     file_id: Mapped[Optional[int]] = mapped_column(ForeignKey("file.id"), nullable=True)
     file: Mapped[Optional["File"]] = relationship(back_populates="group_roles")


### PR DESCRIPTION
### Summary:
Introduces commands for listing, creating, renaming, and managing users within groups via the admin CLI.

### Technical Details:
*   **Command-Line Interface (CLI) Additions:**
    *   The `src/admin.py` file now includes new Typer commands for group management:
        *   `list_groups`: Displays a table of all groups, including their names, descriptions, number of users, and creation timestamps.
        *   `create_group`: Creates a new group with a specified name and optional description.  Includes a check to prevent duplicate group creation.
        *   `rename_group`: Renames an existing group.  Includes error handling for non-existent groups.
        *   `add_user_to_group`: Adds an existing user to a specified group.  Includes error handling for non-existent groups or users.