### PR TITLE
Implement folder pagination and improve folder query efficiency

### DIFF
--- a/src/api/v1/folders.py
+++ b/src/api/v1/folders.py
@@ -99,8 +99,10 @@ def get_shared_folders(
 def get_all_folders(
     db: Session = Depends(get_db_connection),
     current_user: schemas.User = Depends(get_current_active_user),
+    page: int = 1,
+    page_size: int = 40,
     q: str | None = None,
-) -> List[schemas.FolderResponseCompact]:
+) -> schemas.FolderListPaginatedResponse:
     """Get all shared folders for a user.
 
     Args:
@@ -111,7 +113,16 @@ def get_all_folders(
     Returns:
         list: list of folders
     """
-    return get_all_folders_from_db(db, current_user, search_term=q)
+    result, total_count = get_all_folders_from_db(
+        db, current_user, search_term=q, page=page, page_size=page_size
+    )
+    response = schemas.FolderListPaginatedResponse(
+        folders=result,
+        total_count=total_count,
+        page=page,
+        page_size=page_size,
+    )
+    return response
 
 
 # Get all sub-folders for a parent folder

--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -86,8 +86,6 @@ class UserResponse(BaseSchema):
 class UserResponseCompact(BaseSchemaCompact):
     display_name: str
     username: str
-    email: Optional[str]
-    auth_method: str
     profile_picture_url: Optional[str]
     uuid: UUID
 
@@ -169,10 +167,19 @@ class FolderResponse(BaseSchema):
 
 
 class FolderResponseCompact(BaseSchema):
+    model_config = ConfigDict(from_attributes=True)
+
     display_name: str
     user: UserResponseCompact
-    workflows: List["WorkflowResponseCompact"]
+    workflows: Optional[List["WorkflowResponseCompact"]]
     selectable: Optional[bool] = False
+
+
+class FolderListPaginatedResponse(BaseModel):
+    folders: List[FolderResponseCompact]
+    page: int
+    page_size: int
+    total_count: int
 
 
 class UserRoleResponse(BaseSchema):
@@ -336,6 +343,8 @@ class WorkflowResponse(BaseSchema):
 
 
 class WorkflowResponseCompact(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
 
 

--- a/src/datastores/sql/database.py
+++ b/src/datastores/sql/database.py
@@ -180,6 +180,14 @@ def before_compile(query):
 
     for desc in query.column_descriptions:
         entity = desc["entity"]
+
+        # Skip if entity is None (happens with UNION queries, subqueries, or count queries)
+        if entity is None:
+            continue
+        # Skip if entity doesn't have is_deleted attribute (for non-model entities)
+        if not hasattr(entity, "is_deleted"):
+            continue
+
         query = query.enable_assertions(False).filter(
             (entity.is_deleted == False) | (entity.is_deleted == None)
         )


### PR DESCRIPTION
### Summary
Introduces pagination to the folder list API and improves folder query performance by using distinct queries and handling edge cases.

### Technical Details:
*   **Pagination Implementation:** The `get_all_folders` endpoint in `src/api/v1/folders.py` now accepts `page` and `page_size` parameters for pagination.  A `FolderListPaginatedResponse` schema was introduced to return folder lists with pagination information.
*   **Database Query Modification:** The `get_all_folders_from_db` function in `src/datastores/sql/crud/folder.py` has been modified to include pagination logic, taking `page` and `page_size` as parameters.  The query now returns a tuple containing the list of folders and the total count of folders. It applies `distinct()` to ensure unique folder objects are returned in the query result.
*   **Edge Case Handling:** Added a check in `src/datastores/sql/database.py` to handle cases where the entity in a query is `None` (common in `UNION` or `COUNT` queries), avoiding errors during query compilation.  Also, queries are skipped when the entity doesn't have an `is_deleted` attribute.
*   **Schema Update:** Added `model_config = ConfigDict(from_attributes=True)` to `FolderResponseCompact` and `WorkflowResponseCompact` to allow populating the schema from attributes.