### PR TITLE
Add workflow report generation

### DIFF
--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -346,6 +346,7 @@ class WorkflowResponseCompact(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
+    display_name: str
 
 
 class WorkflowStatusResponse(BaseSchema):
@@ -384,6 +385,11 @@ class WorkflowTemplateResponse(BaseSchema):
 
 class WorkflowGeneratedNameResponse(BaseModel):
     generated_name: str
+
+
+class WorkflowReportResponse(BaseModel):
+    workflow: WorkflowResponseCompact
+    markdown: str
 
 
 class Task(BaseSchema):

--- a/src/config.py
+++ b/src/config.py
@@ -23,13 +23,11 @@ from openrelik_ai_common.providers import manager
 
 def get_config() -> dict:
     """Load the settings from the settings.toml file."""
-    project_dir = os.path.normpath(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    )
+    project_dir = os.path.normpath(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     settings_from_env = os.getenv("OPENRELIK_SERVER_SETTINGS")
     # To ensure tests can be loaded even if we don't have a settings.toml file
     # or we didn't set the environment variable (e.g. vanilla VScode devcontainer)
-    if 'pytest' in sys.modules:
+    if "pytest" in sys.modules:
         settings_file = os.path.join(project_dir, "settings_example.toml")
     else:
         settings_file = os.path.join(project_dir, "settings.toml")
@@ -41,12 +39,21 @@ def get_config() -> dict:
         config = tomllib.load(fh)
     return config
 
+
 def get_active_llms() -> dict:
     """Get active LLM providers from the LLM manager."""
     llm_manager = manager.LLMManager()
     llm_providers = list(llm_manager.get_providers())
     active_llms = [provider_class().to_dict() for _, provider_class in llm_providers]
     return active_llms
+
+
+def get_ui_server_url() -> str:
+    """Get the UI server URL from the config."""
+    ui_server_url = config.get("server", {}).get("ui_server_url")
+    if not ui_server_url:
+        raise HTTPException(status_code=500, detail="UI server URL is not configured.")
+    return ui_server_url
 
 
 config = get_config()

--- a/src/lib/reporting_utils.py
+++ b/src/lib/reporting_utils.py
@@ -1,0 +1,178 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility functions for generating formatted reports."""
+
+import string
+import textwrap
+from enum import IntEnum
+
+from config import config
+
+
+# TODO: Move to a common location for use by both server and workers.
+class Priority(IntEnum):
+    """Reporting priority enum to store common values."""
+
+    CRITICAL = 80
+    HIGH = 40
+    MEDIUM = 20
+    LOW = 10
+    INFO = 5
+
+
+def create_workflow_report(
+    workflow: object,
+    min_priority: int = Priority.HIGH,
+    max_priority: int = Priority.CRITICAL,
+    include_header: bool = True,
+):
+    """
+    Creates a markdown report string from a completed workflow run.
+
+    Args:
+        workflow: The workflow object containing tasks and reports.
+        min_priority: Minimum priority level to include in the report.
+        max_priority: Maximum priority level to include in the report.
+        include_header: Whether to include a header section with workflow info.
+    """
+
+    # Convert int parameters to Priority objects if needed
+    if isinstance(min_priority, int):
+        min_priority = Priority(min_priority)
+    if isinstance(max_priority, int):
+        max_priority = Priority(max_priority)
+
+    # Define template strings with a placeholder for conditional lines
+    # The final template object will be created later inside the loop
+    HEADER_TEMPLATE_STR = """
+    # OpenRelik: $workflow_name
+    ## $workflow_name
+    $workflow_url
+    """
+
+    TASK_REPORT_TEMPLATE_STR = """
+    ## $summary
+    * Task: $task_name ($runtime)
+    * Priority: $priority_name
+    ##### Details
+    $markdown
+    ---
+    """
+
+    FILE_REPORT_TEMPLATE_STR = """
+    ## $summary
+    * Task: $task_name ($runtime)
+    * Priority: $priority_name
+    * Link to artifact: [$file_name]($file_url)
+    {source_file_bullet}
+    {original_path_bullet}
+    ##### Details
+    $markdown
+    ---
+    """
+
+    # Base URL for links
+    base_url = config.get("server", {}).get("ui_server_url")
+
+    # Initialize list to hold report sections
+    report_sections = []
+
+    has_reports = False
+
+    # Handle the header section
+    if include_header:
+        workflow_url = f"{base_url}/folder/{workflow.folder.id}/"
+        header_template = string.Template(textwrap.dedent(HEADER_TEMPLATE_STR).strip())
+        header = header_template.substitute(
+            workflow_name=workflow.display_name, workflow_url=workflow_url
+        )
+        report_sections.append(header)
+
+    # Iterate through tasks and their reports
+    for task in workflow.tasks:
+        task_markdown_content = ""
+
+        if task.task_report and min_priority <= task.task_report.priority <= max_priority:
+            has_reports = True
+            task_report_template = string.Template(
+                textwrap.dedent(TASK_REPORT_TEMPLATE_STR).strip()
+            )
+
+            # Determine if summary should be bold based on priority
+            priority_level = Priority(task.task_report.priority)
+            summary = task.task_report.summary
+            if priority_level >= Priority.HIGH:
+                summary = f"**{summary}**"
+
+            task_markdown_content += task_report_template.substitute(
+                summary=summary,
+                task_name=task.display_name,
+                runtime=f"{round(task.runtime, 2)}s",
+                priority_name=priority_level.name,
+                markdown=task.task_report.markdown,
+            )
+
+        for file_report in task.file_reports:
+            if min_priority <= file_report.priority <= max_priority:
+                has_reports = True
+                file_url = f"{base_url}/folder/{workflow.folder.id}/file/{file_report.file.id}"
+
+                # Determine if summary should be bold based on priority
+                priority_level = Priority(file_report.priority)
+                summary = file_report.summary
+                if priority_level >= Priority.HIGH:
+                    summary = f"**{summary}**"
+
+                # Conditional bullets
+                source_file_bullet = (
+                    f"* Extracted from: [{file_report.file.source_file.display_name}]({base_url}/folder/{file_report.file.source_file.folder.id}/file/{file_report.file.source_file.id})"
+                    if file_report.file.source_file
+                    else ""
+                )
+                original_path_bullet = (
+                    f"* Original path: {file_report.file.original_path}"
+                    if file_report.file.original_path
+                    else ""
+                )
+
+                final_template_str = textwrap.dedent(
+                    FILE_REPORT_TEMPLATE_STR.format(
+                        source_file_bullet=source_file_bullet,
+                        original_path_bullet=original_path_bullet,
+                    )
+                ).strip()
+
+                # Create the template object
+                file_report_template = string.Template(final_template_str)
+
+                task_markdown_content += file_report_template.substitute(
+                    summary=summary,
+                    task_name=task.display_name,
+                    runtime=f"{round(task.runtime, 2)}s",
+                    file_name=file_report.file.display_name,
+                    file_url=file_url,
+                    priority_name=Priority(file_report.priority).name,
+                    markdown=file_report.markdown,
+                )
+
+        if task_markdown_content:
+            report_sections.append(task_markdown_content)
+
+    if not has_reports:
+        report_sections.append(
+            f"\nNo reports matching the priority filter were found ({min_priority.name} to {max_priority.name})"
+        )
+
+    final_report = "\n".join(report_sections)
+    return final_report

--- a/src/tests/lib/reporting_utils_test.py
+++ b/src/tests/lib/reporting_utils_test.py
@@ -1,0 +1,103 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lib.reporting_utils import Priority, create_workflow_report
+
+
+@pytest.fixture
+def mock_config(monkeypatch):
+    """Fixture to mock the config module."""
+    mock_config_dict = {"server": {"ui_server_url": "https://example.com"}}
+    monkeypatch.setattr(
+        "lib.reporting_utils.config", MagicMock(get=lambda *args: mock_config_dict.get(*args))
+    )
+
+
+@pytest.fixture
+def mock_workflow():
+    """Fixture to create a mock workflow object with a task and a report."""
+    # Mock workflow and folder
+    mock_folder = MagicMock(id="123")
+    mock_workflow = MagicMock(display_name="Test Workflow", folder=mock_folder, tasks=[])
+
+    # Mock task and reports
+    mock_task = MagicMock(
+        display_name="Test Task",
+        runtime=10.5123,
+        task_report=MagicMock(
+            priority=Priority.HIGH,
+            summary="High Priority Summary",
+            markdown="This is a test report.",
+        ),
+        file_reports=[],
+    )
+
+    # Mock file report
+    mock_source_file = MagicMock(
+        display_name="source_file.txt",
+        folder=mock_folder,
+        id="source_file_id_456",
+    )
+    mock_file = MagicMock(
+        display_name="test_file.txt",
+        original_path="path/to/original/file.txt",
+        source_file=mock_source_file,
+        id="file_id_789",
+    )
+
+    mock_file_report = MagicMock(
+        priority=Priority.CRITICAL,
+        summary="Critical File Report",
+        markdown="This is a critical file report.",
+        file=mock_file,
+    )
+
+    mock_task.file_reports = [mock_file_report]
+    mock_workflow.tasks = [mock_task]
+
+    return mock_workflow
+
+
+def test_create_workflow_report(mock_workflow, mock_config):
+    """Test that create_workflow_report generates the correct markdown string."""
+    # Call the function with the mock workflow object
+    report_output = create_workflow_report(mock_workflow)
+
+    # Define the expected output string
+    expected_output = (
+        "# OpenRelik: Test Workflow\n"
+        "## Test Workflow\n"
+        "https://example.com/folder/123/\n"
+        "## **High Priority Summary**\n"
+        "* Task: Test Task (10.51s)\n"
+        "* Priority: HIGH\n"
+        "##### Details\n"
+        "This is a test report.\n"
+        "---## **Critical File Report**\n"
+        "* Task: Test Task (10.51s)\n"
+        "* Priority: CRITICAL\n"
+        "* Link to artifact: [test_file.txt](https://example.com/folder/123/file/file_id_789)\n"
+        "* Extracted from: [source_file.txt](https://example.com/folder/123/file/source_file_id_456)\n"
+        "* Original path: path/to/original/file.txt\n"
+        "##### Details\n"
+        "This is a critical file report.\n"
+        "---"
+    )
+
+    # Assert that the generated report matches the expected output
+    assert report_output.strip() == expected_output.strip()


### PR DESCRIPTION
### Summary
Adds the ability to generate workflow reports in markdown format.

<img width="726" height="556" alt="Screenshot 2025-09-12 at 13 58 37" src="https://github.com/user-attachments/assets/385158a3-547b-4590-aacf-491865c6d8a3" />

### Technical Details:
*   **Schema Addition:** A `WorkflowReportResponse` schema is added in `src/api/v1/schemas.py`. This schema encapsulates the workflow details and the generated markdown report.
*   **API Endpoint Addition:**  A new GET endpoint `/workflows/{workflow_id}/report/` is introduced in `src/api/v1/workflows.py`.  This endpoint triggers the workflow report generation.  It also includes authentication checks.
*   **Configuration:** Adds a check in `src/config.py` to ensure that the UI server URL is configured.
*   **Report Generation Logic:** The `create_workflow_report` function is introduced in `src/lib/reporting_utils.py`. This function takes a workflow object as input and returns a markdown string containing the workflow report. This includes filtering of reports based on priority, and includes the logic to add links to files and source files in the UI.
*   **Testing:** Added `src/tests/lib/reporting_utils_test.py` to test the report generation logic.