### PR TITLE
Add support for Google Robot Accounts (Service Accounts)

### DIFF
--- a/settings_example.toml
+++ b/settings_example.toml
@@ -49,6 +49,9 @@ workspace_domain = ""
 # Allow only these users (email address) to access the server.
 allowlist = ["<REPLACE_WITH_USERNAME>@gmail.com"]
 
+# Allow these robot accounts (service accounts) to access the server.
+allowed_robot_accounts = []
+
 # Allow anyone (who is authenticated) to access the server.
 # Note: If a workspace_domain is set then the public_access is limited to that domain.
 # WARNING: This allows anyone to login to your server!


### PR DESCRIPTION
### Summary
Adds the ability for robot accounts (service accounts) to access the server, bypassing domain restrictions.

### Technical Details:
*   **Configuration Option:** Introduced a new configuration option `allowed_robot_accounts` in `settings_example.toml` to specify a list of email addresses for robot accounts.
*   **Authentication Logic:** Modified the `_validate_user_info` function in `src/auth/google.py` to allow robot accounts (specified in `GOOGLE_ALLOWED_ROBOT_ACCOUNTS`) to bypass the Google Workspace domain check. This allows service accounts to authenticate without belonging to a specific domain.