### PR TITLE
Add Support for Workflow Template Parameters

### DIFF
--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -357,6 +357,7 @@ class WorkflowCreateRequest(BaseModel):
     folder_id: int
     file_ids: List[int]
     template_id: Optional[int] = None
+    template_params: Optional[dict] = None
 
 
 class WorkflowRunRequest(BaseModel):

--- a/src/datastores/sql/crud/workflow.py
+++ b/src/datastores/sql/crud/workflow.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import uuid
 
 from sqlalchemy.orm import Session
 
-from datastores.sql.models.workflow import Workflow, Task, TaskReport, WorkflowTemplate
 from api.v1 import schemas
-
-from datastores.sql.crud.file import get_file_from_db, get_file_by_uuid_from_db
+from datastores.sql.crud.file import get_file_from_db
+from datastores.sql.models.workflow import Task, TaskReport, Workflow, WorkflowTemplate
+from lib import workflow_utils
 
 
 def get_file_workflows_from_db(db: Session, file_id: int) -> list[Workflow]:
@@ -65,13 +66,12 @@ def get_workflow_from_db(db: Session, workflow_id: int) -> Workflow:
     return db.get(Workflow, workflow_id)
 
 
-def create_workflow_in_db(db: Session, workflow: schemas.Workflow, template_id: int) -> Workflow:
+def create_workflow_in_db(db: Session, workflow: schemas.Workflow) -> Workflow:
     """Create a new workflow.
 
     Args:
         db (Session): SQLAlchemy session object
         workflow (Workflow): Workflow object
-        template_id (int): ID of the workflow template
 
     Returns:
         Workflow object
@@ -124,14 +124,14 @@ def delete_workflow_from_db(db: Session, workflow_id: int):
 
 def delete_workflow_template_from_db(db: Session, workflow_template_id: int):
     """Deles a workflow template in the database.
-    
+
     Args:
         db (Session): SQLAlchemy session object
         workflow_template_id (int): ID of the workflow template
     """
     workflow_template = db.get(WorkflowTemplate, workflow_template_id)
     if not workflow_template:
-        raise ValueError(f"Workflow template with id {workflow_template_id} not found") 
+        raise ValueError(f"Workflow template with id {workflow_template_id} not found")
     db.delete(workflow_template)
     db.commit()
 
@@ -158,7 +158,49 @@ def get_workflow_templates_from_db(db: Session) -> list[WorkflowTemplate]:
     Returns:
         List of WorkflowTemplate objects
     """
-    return db.query(WorkflowTemplate).order_by(WorkflowTemplate.id.desc()).all()
+
+    def _get_and_update_templates():
+        """
+        Retrieve all workflow templates and update them to include unique param names if they
+        don't already have them.
+
+        Temporary function to ensure all templates have unique param names.
+        Remove this function in the future once all templates have been updated.
+
+        Returns:
+            List of WorkflowTemplate objects
+        """
+        templates_to_return = []
+        all_templates = db.query(WorkflowTemplate).order_by(WorkflowTemplate.id.desc()).all()
+
+        for template in all_templates:
+            # If the template does not have task_config, skip processing early
+            if '"task_config"' not in template.spec_json:
+                templates_to_return.append(template)
+                continue
+
+            # Check if the template already has param_name and skip if it does
+            if '"param_name"' not in template.spec_json:
+                try:
+                    # Parse the JSON and add the param_name
+                    spec_json_dict = json.loads(template.spec_json)
+                    workflow_utils.add_unique_parameter_names(spec_json_dict)
+
+                    # Update the database record
+                    template.spec_json = json.dumps(spec_json_dict)
+                    db.add(template)
+                    db.commit()
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
+            templates_to_return.append(template)
+        return templates_to_return
+
+    # Temporary fix to update all templates to have unique param names. This ensures that
+    # users can use the template parameters feature without manually updating the templates.
+    # TODO: This should be removed in the future once all templates have been updated. Replace with
+    # db.query(WorkflowTemplate).order_by(WorkflowTemplate.id.desc()).all()
+    return _get_and_update_templates()
 
 
 def create_workflow_template_in_db(
@@ -183,10 +225,8 @@ def create_workflow_template_in_db(
     db.refresh(db_template)
     return db_template
 
-def update_workflow_template_in_db(
-    db: Session,
-    template: WorkflowTemplate
-) -> WorkflowTemplate:
+
+def update_workflow_template_in_db(db: Session, template: WorkflowTemplate) -> WorkflowTemplate:
     """Update a workflow template.
 
     Args:

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+
+
+def update_task_config_values(data: dict | list, parameters: dict) -> None:
+    """
+    Recursively traverses a dictionary or list to find 'task_config' lists
+    and updates the 'value' of each item based on the unique 'param_name'.
+
+    Args:
+        data (dict | list): The dictionary or list to traverse.
+        parameters (dict): A dictionary where keys are the unique 'param_name'.
+    """
+    if isinstance(data, dict):
+        task_config = data.get("task_config", [])
+        for item in task_config:
+            param_name = item.get("param_name")
+            if not param_name:
+                continue
+
+            if param_name in parameters:
+                item["value"] = parameters[param_name]
+                continue
+
+        for key, value in data.items():
+            update_task_config_values(value, parameters)
+
+    elif isinstance(data, list):
+        for item in data:
+            update_task_config_values(item, parameters)
+
+
+def add_unique_parameter_names(data: dict | list) -> None:
+    """
+    Wrapper function to initiate the recursive traversal with a shared counter.
+
+    Args:
+        data (dict | list): The workflow dictionary to modify.
+    """
+    _add_unique_parameter_names_recursive(data, defaultdict(int))
+
+
+def _add_unique_parameter_names_recursive(data: dict | list, counts: defaultdict) -> None:
+    """
+    Recursively traverses a workflow dictionary and adds a unique
+    "param_name" key to each task_config item that has a "name" key.
+    The "param_name" is created by lowercasing the original name and
+    replacing spaces with underscores, followed by a unique index.
+
+    Args:
+        data (dict | list): The workflow dictionary to modify.
+        counts (defaultdict): A dictionary to keep track of the counts of each normalized name.
+    """
+    if isinstance(data, dict):
+        if "task_config" in data and isinstance(data["task_config"], list):
+            for item in data["task_config"]:
+                if "name" in item:
+                    normalized_name = item["name"].lower().replace(" ", "_")
+                    param_name = f"{normalized_name}_{counts[normalized_name]}"
+                    item["param_name"] = param_name
+                    counts[normalized_name] += 1
+
+        for key, value in data.items():
+            _add_unique_parameter_names_recursive(value, counts)
+
+    elif isinstance(data, list):
+        for item in data:
+            _add_unique_parameter_names_recursive(item, counts)

--- a/src/tests/lib/workflow_utils_test.py
+++ b/src/tests/lib/workflow_utils_test.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from lib.workflow_utils import add_unique_parameter_names, update_task_config_values
+
+
+@pytest.fixture
+def template_data():
+    test_template_str = '{"workflow": {"type": "chain", "isRoot": true, "tasks": [{"task_name": "openrelik-worker-strings.tasks.strings", "queue_name": "openrelik-worker-strings", "display_name": "Strings", "description": "Extract strings from files", "task_config": [{"name": "UTF16LE", "label": "Extract Unicode strings", "description": "This will tell the strings command to extract UTF-16LE (little endian) encoded strings", "type": "checkbox", "value": true}, {"name": "ASCII", "label": "Extract ASCII strings", "description": "This will tell the strings command to extract ASCII (single-7-bit-byte) encoded strings", "type": "checkbox", "value": false}], "type": "task", "uuid": "e1e6703d5724474aa2a509e9de605430", "tasks": []}, {"task_name": "openrelik-worker-strings.tasks.strings", "queue_name": "openrelik-worker-strings", "display_name": "Strings", "description": "Extract strings from files", "task_config": [{"name": "UTF16LE", "label": "Extract Unicode strings", "description": "This will tell the strings command to extract UTF-16LE (little endian) encoded strings", "type": "checkbox", "value": true}, {"name": "ASCII", "label": "Extract ASCII strings", "description": "This will tell the strings command to extract ASCII (single-7-bit-byte) encoded strings", "type": "checkbox", "value": false}], "type": "task", "uuid": "736a973ffae24081a75abd1d22b8633c", "tasks": []}]}}'
+    return json.loads(test_template_str)
+
+
+def test_add_unique_parameter_names(template_data):
+    """
+    Tests that add_unique_parameter_names correctly adds unique param_name keys.
+    """
+    add_unique_parameter_names(template_data)
+
+    # Check the first task's config
+    first_task_config = template_data["workflow"]["tasks"][0]["task_config"]
+    assert "param_name" in first_task_config[0]
+    assert first_task_config[0]["param_name"] == "utf16le_0"
+    assert "param_name" in first_task_config[1]
+    assert first_task_config[1]["param_name"] == "ascii_0"
+
+    # Check the second task's config to ensure uniqueness
+    second_task_config = template_data["workflow"]["tasks"][1]["task_config"]
+    assert "param_name" in second_task_config[0]
+    assert second_task_config[0]["param_name"] == "utf16le_1"
+    assert "param_name" in second_task_config[1]
+    assert second_task_config[1]["param_name"] == "ascii_1"
+
+
+def test_update_task_config_values(template_data):
+    """
+    Tests that update_task_config_values correctly updates the 'value' based on parameters.
+    """
+    # First, add the unique parameter names to have a key to update
+    add_unique_parameter_names(template_data)
+
+    # Define the parameters to update
+    parameters = {"utf16le_0": False, "ascii_0": True, "utf16le_1": False, "ascii_1": True}
+
+    # Update the values
+    update_task_config_values(template_data, parameters)
+
+    # Check the updated values for the first task
+    first_task_config = template_data["workflow"]["tasks"][0]["task_config"]
+    assert first_task_config[0]["value"] is False
+    assert first_task_config[1]["value"] is True
+
+    # Check the updated values for the second task
+    second_task_config = template_data["workflow"]["tasks"][1]["task_config"]
+    assert second_task_config[0]["value"] is False
+    assert second_task_config[1]["value"] is True
+
+
+def test_update_with_missing_param_name(template_data):
+    """
+    Tests that update_task_config_values gracefully handles a missing param_name in the parameters.
+    """
+    add_unique_parameter_names(template_data)
+
+    parameters = {
+        "utf16le_0": False,
+        "ascii_0": True,
+    }
+
+    # Update the values with a subset of parameters
+    update_task_config_values(template_data, parameters)
+
+    # Check that the specified values are updated
+    first_task_config = template_data["workflow"]["tasks"][0]["task_config"]
+    assert first_task_config[0]["value"] is False
+    assert first_task_config[1]["value"] is True
+
+    # Check that the second task's values remain unchanged because their param_names weren't in the parameters dict
+    second_task_config = template_data["workflow"]["tasks"][1]["task_config"]
+    assert second_task_config[0]["value"] is True
+    assert second_task_config[1]["value"] is False


### PR DESCRIPTION
### Summary
Adds the ability to customize workflow templates with parameters on creation.

Every parameter in a template can be changed using a uniq identifier for each parameter. These are created when the template is created using the following naming scheme: "{config_parameter_name}_{index}". So if there are multiple tasks with the same parameter these can be individually modified. Example:

```
{
  "ascii_0": True,
  "ascii_1": False
}
```

Use from API client:
```
post_data = {"file_ids": [2976], "folder_id": 244, "template_id": 5, "template_params":  {"ascii_0": True}}
api_client.post("/folders/244/workflows/", json=post_data)
```

### Technical Details:
*   **Schema Modification:** The `WorkflowCreateRequest` schema in `src/api/v1/schemas.py` now includes an optional `template_params` field, which allows specifying parameter values to use when creating a workflow from a template.
*   **API Endpoint Update:** The `create_workflow` function in `src/api/v1/workflows.py` has been modified to accept and process the `template_params` from the request body.  It now passes these parameters to a new function `workflow_utils.update_task_config_values` to apply them to the workflow template.
*   **Template Parameterization Logic:** A new module `src/lib/workflow_utils.py` is introduced, containing the function `update_task_config_values` to replace placeholder values in the task configurations based on provided parameters. It also contains `add_unique_parameter_names` to update existing workflow templates.
*   **Template Parameter Auto-Migration:** The `get_workflow_templates_from_db` function in `src/datastores/sql/crud/workflow.py` now attempts to automatically add unique parameter names to existing workflow templates if they are missing, ensuring compatibility with the new parameterization feature.
*   **Unit Tests:** Added unit tests for the new parameterization logic in `src/tests/lib/workflow_utils_test.py`.