### PR TITLE
Add unit tests for API modules

### DIFF
--- a/src/tests/api/v1/configs_test.py
+++ b/src/tests/api/v1/configs_test.py
@@ -25,4 +25,6 @@ def test_get_system_config(fastapi_test_client, mocker):
     response = fastapi_test_client.get("/configs/system/")
     assert response.status_code == 200
     assert response.json()["active_llms"] == mock_active_llms
-    assert response.json()["allowed_data_types_preview"] == ["openrelik:hayabusa:html_report"]
+    assert response.json()["allowed_data_types_preview"] == [
+        "openrelik:hayabusa:html_report"
+    ]

--- a/src/tests/api/v1/conftest.py
+++ b/src/tests/api/v1/conftest.py
@@ -74,7 +74,10 @@ def setup_file_path_mock(mocker, file_db_model, setup_config_mock):
 
     # 3. Mock the 'path' property on the file_db_model class to return the expected path
     mocker.patch.object(
-        file_db_model.__class__, "path", new_callable=mocker.PropertyMock, return_value=expected_path
+        file_db_model.__class__,
+        "path",
+        new_callable=mocker.PropertyMock,
+        return_value=expected_path,
     )
 
     # Return the expected path for tests that need to assert on the 'open' call

--- a/src/tests/api/v1/conftest.py
+++ b/src/tests/api/v1/conftest.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-from unittest.mock import PropertyMock
 
 import pytest
 
@@ -75,7 +74,7 @@ def setup_file_path_mock(mocker, file_db_model, setup_config_mock):
 
     # 3. Mock the 'path' property on the file_db_model class to return the expected path
     mocker.patch.object(
-        file_db_model.__class__, "path", new_callable=PropertyMock, return_value=expected_path
+        file_db_model.__class__, "path", new_callable=mocker.PropertyMock, return_value=expected_path
     )
 
     # Return the expected path for tests that need to assert on the 'open' call

--- a/src/tests/api/v1/files_test.py
+++ b/src/tests/api/v1/files_test.py
@@ -16,7 +16,6 @@
 
 import json
 import os
-from unittest.mock import PropertyMock
 
 import pytest
 
@@ -191,7 +190,7 @@ async def test_upload_files_chunked(
     mocker.patch.object(
         folder_db_model.__class__,
         "path",
-        new_callable=PropertyMock,
+        new_callable=mocker.PropertyMock,
         return_value=expected_folder_path,
     )
 
@@ -386,3 +385,294 @@ def test_generate_query(fastapi_test_client, mocker, file_db_model, setup_file_p
         "user_request": user_request,
         "generated_query": "SELECT * FROM table1 LIMIT 10;",
     }
+
+
+def test_get_file_content_encoding_fallback(
+    fastapi_test_client, mocker, file_db_model, setup_file_path_mock
+):
+    """Test get_file_content falls back to other encodings."""
+    expected_path = setup_file_path_mock
+    mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
+    mock_get_file_from_db.return_value = file_db_model
+
+    def side_effect(path, mode, encoding=None):
+        if encoding == "utf-8":
+            raise UnicodeDecodeError("utf-8", b"", 0, 1, "")
+        # Mocking a file handle that returns content on read
+        m = mocker.mock_open(read_data="Fallback content").return_value
+        return m
+
+    mocker.patch("builtins.open", side_effect=side_effect)
+
+    response = fastapi_test_client.get(f"/files/{file_db_model.id}/content")
+    assert response.status_code == 200
+    assert "Fallback content" in response.text
+
+
+def test_get_file_content_unescaped(
+    fastapi_test_client, mocker, file_db_model, setup_file_path_mock
+):
+    """Test get_file_content with unescaped content."""
+    expected_path = setup_file_path_mock
+    mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
+    file_db_model.data_type = "text/html"
+    mock_get_file_from_db.return_value = file_db_model
+
+    mocker.patch("api.v1.files.ALLOWED_DATA_TYPES_PREVIEW", ["text/html"])
+
+    file_content = "<b>Bold Content</b>"
+    mock_open = mocker.mock_open(read_data=file_content)
+    mocker.patch("builtins.open", mock_open)
+
+    response = fastapi_test_client.get(
+        f"/files/{file_db_model.id}/content?unescaped=True"
+    )
+    assert response.status_code == 200
+    assert file_content in response.text
+
+
+@pytest.mark.asyncio
+async def test_upload_files_complete(
+    fastapi_async_test_client,
+    mocker,
+    folder_db_model,
+    file_db_model,
+    file_response,
+    setup_config_mock,
+):
+    """Test upload_files endpoint when all chunks are uploaded."""
+    mock_config = setup_config_mock
+    temp_storage_path = mock_config["server"]["storage"]["providers"]["default"]["path"]
+
+    folder_db_model.storage_provider = "default"
+    folder_db_model.storage_key = f"folder_path_{folder_db_model.id}"
+
+    expected_folder_path = os.path.join(temp_storage_path, folder_db_model.storage_key)
+    os.makedirs(expected_folder_path, exist_ok=True)
+
+    mocker.patch.object(
+        folder_db_model.__class__,
+        "path",
+        new_callable=mocker.PropertyMock,
+        return_value=expected_folder_path,
+    )
+
+    mock_get_folder_from_db = mocker.patch("api.v1.files.get_folder_from_db")
+    mock_get_folder_from_db.return_value = folder_db_model
+    mock_create_file_in_db = mocker.patch("api.v1.files.create_file_in_db")
+    mock_create_file_in_db.return_value = file_response
+    mock_background_tasks_add_task = mocker.patch("api.v1.files.BackgroundTasks.add_task")
+    
+    # Mock Redis
+    mock_redis = mocker.patch("api.v1.files.redis_client")
+    mock_redis.smembers.return_value = {b"1", b"2", b"3"}
+    
+    resumable_identifier = "12345"
+    resumable_filename = "test_file.txt"
+    folder_id = folder_db_model.id
+    chunk_size = 1024
+    total_chunks = 3
+    total_size = chunk_size * total_chunks
+    chunk_number = 3
+    
+    # Create dummy chunk files
+    for i in range(1, total_chunks + 1):
+        chunk_path = os.path.join(expected_folder_path, f"{resumable_identifier}.{i}")
+        with open(chunk_path, "w") as f:
+            f.write(f"content of chunk {i}")
+
+    response = await fastapi_async_test_client.post(
+        "/files/upload",
+        files={"file": ("test_file.txt", b"last chunk content")},
+        params={
+            "resumableChunkNumber": chunk_number,
+            "resumableChunkSize": chunk_size,
+            "resumableCurrentChunkSize": chunk_size,
+            "resumableTotalSize": total_size,
+            "resumableTotalChunks": total_chunks,
+            "resumableIdentifier": resumable_identifier,
+            "resumableFilename": resumable_filename,
+            "folder_id": folder_id,
+        },
+    )
+    assert response.status_code == 201
+    assert mock_create_file_in_db.called
+    assert mock_background_tasks_add_task.called
+
+
+def test_generate_file_summary_no_llm(fastapi_test_client, mocker, file_db_model):
+    """Test generate_file_summary endpoint when no active LLM."""
+    mock_get_active_llm = mocker.patch("api.v1.files.get_active_llm")
+    mock_get_active_llm.return_value = None  # No active LLM
+    mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
+    mock_get_file_from_db.return_value = file_db_model
+
+    response = fastapi_test_client.post(f"/files/{file_db_model.id}/summaries")
+    assert response.status_code == 503
+    assert response.json()["detail"] == "No active LLM available."
+
+
+def test_run_sql_query_non_sql(fastapi_test_client, mocker, file_db_model):
+    """Test run_sql_query with non-SQL file."""
+    mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
+    mock_get_file_from_db.return_value = file_db_model
+    mock_is_sql_file = mocker.patch("lib.duckdb_utils.is_sql_file")
+    mock_is_sql_file.return_value = False
+
+    response = fastapi_test_client.post(
+        f"/files/{file_db_model.id}/sql/query",
+        json={"query": "SELECT * FROM table1 LIMIT 10;"},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "File is not a supported SQL format."
+
+
+def test_run_sql_query_limit_exceeded(
+    fastapi_test_client, mocker, file_db_model
+):
+    """Test run_sql_query with LIMIT exceeding max."""
+    mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
+    mock_get_file_from_db.return_value = file_db_model
+    mock_is_sql_file = mocker.patch("lib.duckdb_utils.is_sql_file")
+    mock_is_sql_file.return_value = True
+
+    response = fastapi_test_client.post(
+        f"/files/{file_db_model.id}/sql/query",
+        json={"query": "SELECT * FROM table1 LIMIT 20000;"},
+    )
+    assert response.status_code == 400
+    assert "LIMIT value cannot exceed" in response.json()["detail"]
+
+
+def test_run_sql_query_runtime_error(fastapi_test_client, mocker, file_db_model):
+    """Test run_sql_query handling runtime error."""
+    mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
+    mock_get_file_from_db.return_value = file_db_model
+    mock_is_sql_file = mocker.patch("lib.duckdb_utils.is_sql_file")
+    mock_is_sql_file.return_value = True
+    mock_run_query = mocker.patch("lib.duckdb_utils.run_query")
+    mock_run_query.side_effect = RuntimeError("DuckDB error")
+
+    response = fastapi_test_client.post(
+        f"/files/{file_db_model.id}/sql/query",
+        json={"query": "SELECT * FROM table1 LIMIT 10;"},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "DuckDB error"
+
+
+def test_get_file_chat_history_empty(fastapi_test_client, mocker):
+    """Test get_file_chat_history when no chat exists."""
+    mock_get_latest_file_chat_from_db = mocker.patch(
+        "api.v1.files.get_latest_file_chat_from_db"
+    )
+    mock_get_latest_file_chat_from_db.return_value = None
+    file_id = 1
+
+    response = fastapi_test_client.get(f"/files/{file_id}/chat/history")
+    assert response.status_code == 200
+    assert response.json() == {
+        "title": None,
+        "history": [],
+        "created_at": None,
+        "deleted_at": None,
+        "id": None,
+        "is_deleted": False,
+        "updated_at": None,
+    }
+
+
+
+def test_get_file_chat_history_with_data(fastapi_test_client, mocker):
+    """Test get_file_chat_history when chat exists."""
+    mock_chat = mocker.Mock()
+    mock_chat.title = "Test Chat"
+    mock_chat.get_chat_history.return_value = [{"role": "user", "content": "hello"}]
+
+    mock_get_latest_file_chat_from_db = mocker.patch(
+        "api.v1.files.get_latest_file_chat_from_db"
+    )
+    mock_get_latest_file_chat_from_db.return_value = mock_chat
+    file_id = 1
+
+    response = fastapi_test_client.get(f"/files/{file_id}/chat/history")
+    assert response.status_code == 200
+    assert response.json() == {
+        "title": "Test Chat",
+        "history": [{"role": "user", "content": "hello"}],
+        "created_at": None,
+        "deleted_at": None,
+        "id": None,
+        "is_deleted": False,
+        "updated_at": None,
+    }
+
+
+
+def test_create_file_chat_message_no_llm(fastapi_test_client, mocker):
+    """Test create_file_chat_message when no LLM available."""
+    mock_get_latest_file_chat_from_db = mocker.patch(
+        "api.v1.files.get_latest_file_chat_from_db"
+    )
+    mock_get_latest_file_chat_from_db.return_value = (
+        mocker.Mock()
+    )  # Assume chat exists
+
+    mock_get_active_llm = mocker.patch("api.v1.files.get_active_llm")
+    mock_get_active_llm.return_value = None  # No active LLM
+
+    file_id = 1
+    response = fastapi_test_client.post(
+        f"/files/{file_id}/chat", json={"prompt": "hello"}
+    )
+    assert response.status_code == 503
+    assert response.json()["detail"] == "No active LLM available."
+
+
+@pytest.mark.asyncio
+async def test_create_file_chat_message_success(
+    fastapi_async_test_client, mocker
+):
+    """Test create_file_chat_message success."""
+    mock_chat_obj = mocker.Mock()
+    mock_chat_obj.id = 1
+    mock_chat_obj.get_chat_history.return_value = []
+
+    mock_get_latest_file_chat_from_db = mocker.patch(
+        "api.v1.files.get_latest_file_chat_from_db"
+    )
+    mock_get_latest_file_chat_from_db.return_value = mock_chat_obj
+
+    mock_get_active_llm = mocker.patch("api.v1.files.get_active_llm")
+    mock_get_active_llm.return_value = {
+        "name": "test_llm",
+        "config": {"model": "test_model"},
+    }
+
+    mock_chat_session = mocker.Mock()
+    mock_chat_session.chat.return_value = "This is the LLM response"
+    mock_create_chat_session = mocker.patch("api.v1.files.create_chat_session")
+    mock_create_chat_session.return_value = mock_chat_session
+
+    mock_create_file_chat_message_in_db = mocker.patch(
+        "api.v1.files.create_file_chat_message_in_db"
+    )
+
+    file_id = 1
+    response = await fastapi_async_test_client.post(
+        f"/files/{file_id}/chat", json={"prompt": "hello"}
+    )
+
+    assert response.status_code == 200
+
+    # Read from stream
+    content = b""
+    async for chunk in response.aiter_bytes():
+        content += chunk
+
+    assert b"This is the LLM response" in content
+    assert mock_create_file_chat_message_in_db.called
+
+
+
+

--- a/src/tests/api/v1/files_test.py
+++ b/src/tests/api/v1/files_test.py
@@ -42,7 +42,9 @@ def test_get_file_content(
     mock_open = mocker.mock_open(read_data=file_content)
     mocker.patch("builtins.open", mock_open)
 
-    response = fastapi_test_client.get(f"/files/{file_db_model.id}/content?theme={theme}")
+    response = fastapi_test_client.get(
+        f"/files/{file_db_model.id}/content?theme={theme}"
+    )
 
     assert response.status_code == 200
     assert (
@@ -85,7 +87,9 @@ def test_get_file_content_file_not_found(
     )
 
 
-@pytest.mark.parametrize("file_id, display_name", [(1, "file1.txt"), (2, "another_file.pdf")])
+@pytest.mark.parametrize(
+    "file_id, display_name", [(1, "file1.txt"), (2, "another_file.pdf")]
+)
 def test_download_file(fastapi_test_client, mocker, file_id, display_name, tmp_path):
     mock_file_response = mocker.Mock()
     mock_file_response.id = file_id
@@ -99,12 +103,17 @@ def test_download_file(fastapi_test_client, mocker, file_id, display_name, tmp_p
     mock_get_file_from_db.return_value = mock_file_response
     response = fastapi_test_client.get(f"/files/{file_id}/download")
     assert response.status_code == 200
-    assert response.headers["content-disposition"] == f'attachment; filename="{display_name}"'
+    assert (
+        response.headers["content-disposition"]
+        == f'attachment; filename="{display_name}"'
+    )
 
 
 def test_get_workflows_empty(fastapi_test_client, mocker):
     """Test the get_workflows endpoint."""
-    mock_get_file_workflows_from_db = mocker.patch("api.v1.files.get_file_workflows_from_db")
+    mock_get_file_workflows_from_db = mocker.patch(
+        "api.v1.files.get_file_workflows_from_db"
+    )
     mock_get_file_workflows_from_db.return_value = []
     file_id = 1
 
@@ -114,7 +123,9 @@ def test_get_workflows_empty(fastapi_test_client, mocker):
 
 def test_get_workflows(fastapi_test_client, mocker, workflow_response):
     """Test the get_workflows endpoint."""
-    mock_get_file_workflows_from_db = mocker.patch("api.v1.files.get_file_workflows_from_db")
+    mock_get_file_workflows_from_db = mocker.patch(
+        "api.v1.files.get_file_workflows_from_db"
+    )
     mock_get_file_workflows_from_db.return_value = [workflow_response]
     file_id = 1
 
@@ -129,9 +140,16 @@ def test_generate_file_summary(
 ):
     """Test generate_file_summary endpoint."""
     mock_get_active_llm = mocker.patch("api.v1.files.get_active_llm")
-    mock_get_active_llm.return_value = {"name": "test_llm", "config": {"model": "test_model"}}
-    mock_create_file_summary_in_db = mocker.patch("api.v1.files.create_file_summary_in_db")
-    mock_background_tasks_add_task = mocker.patch("api.v1.files.BackgroundTasks.add_task")
+    mock_get_active_llm.return_value = {
+        "name": "test_llm",
+        "config": {"model": "test_model"},
+    }
+    mock_create_file_summary_in_db = mocker.patch(
+        "api.v1.files.create_file_summary_in_db"
+    )
+    mock_background_tasks_add_task = mocker.patch(
+        "api.v1.files.BackgroundTasks.add_task"
+    )
 
     response = fastapi_test_client.post(f"/files/{file_db_model.id}/summaries")
     assert response.status_code == 200
@@ -152,7 +170,9 @@ async def test_download_file_stream(
     with open(expected_path, "w") as f:
         f.write("Dummy file content")
 
-    response = await fastapi_async_test_client.get(f"/files/{file_db_model.id}/download_stream")
+    response = await fastapi_async_test_client.get(
+        f"/files/{file_db_model.id}/download_stream"
+    )
     assert response.status_code == 200
     assert (
         response.headers["content-disposition"]
@@ -203,7 +223,9 @@ async def test_upload_files_chunked(
     mock_get_folder_from_db.return_value = folder_db_model
     mock_create_file_in_db = mocker.patch("api.v1.files.create_file_in_db")
     mock_create_file_in_db.return_value = file_response
-    mock_background_tasks_add_task = mocker.patch("api.v1.files.BackgroundTasks.add_task")
+    mock_background_tasks_add_task = mocker.patch(
+        "api.v1.files.BackgroundTasks.add_task"
+    )
     resumable_identifier = "12345"
     resumable_filename = "test_file.txt"
     folder_id = folder_db_model.id
@@ -211,7 +233,9 @@ async def test_upload_files_chunked(
     total_chunks = 3
     total_size = chunk_size * total_chunks
     chunk_number = 1
-    current_chunk_size = chunk_size if chunk_number < total_chunks else total_size % chunk_size
+    current_chunk_size = (
+        chunk_size if chunk_number < total_chunks else total_size % chunk_size
+    )
 
     chunk_content = b"test file content" * (chunk_size // len(b"test file content"))
     response = await fastapi_async_test_client.post(
@@ -241,7 +265,9 @@ def test_get_task(fastapi_test_client, mocker, db, task_response):
     file_id = 1
     workflow_id = 1
     task_id = 1
-    response = fastapi_test_client.get(f"/files/{file_id}/workflows/{workflow_id}/tasks/{task_id}")
+    response = fastapi_test_client.get(
+        f"/files/{file_id}/workflows/{workflow_id}/tasks/{task_id}"
+    )
 
     assert response.status_code == 200
     mock_get_task_from_db.assert_called_once_with(db, task_id)
@@ -265,7 +291,9 @@ def test_get_file_summary(fastapi_test_client, mocker, db):
         "llm_model_config": None,
         "file_id": 1,
     }
-    mock_get_file_summary_from_db = mocker.patch("api.v1.files.get_file_summary_from_db")
+    mock_get_file_summary_from_db = mocker.patch(
+        "api.v1.files.get_file_summary_from_db"
+    )
     mock_get_file_summary_from_db.return_value = mock_summary
 
     file_id = 1
@@ -295,11 +323,16 @@ def test_download_task_result(fastapi_test_client, mocker, db, tmp_path):
     )
 
     assert response.status_code == 200
-    assert response.headers["content-disposition"] == 'attachment; filename="test_result.txt"'
+    assert (
+        response.headers["content-disposition"]
+        == 'attachment; filename="test_result.txt"'
+    )
     assert response.content == b"Test result content"
 
 
-def test_get_sql_schemas(fastapi_test_client, mocker, file_db_model, setup_file_path_mock):
+def test_get_sql_schemas(
+    fastapi_test_client, mocker, file_db_model, setup_file_path_mock
+):
     """Test the get_sql_schemas endpoint."""
     setup_file_path_mock
 
@@ -328,7 +361,9 @@ def test_get_sql_schemas(fastapi_test_client, mocker, file_db_model, setup_file_
     assert response.status_code == 400
 
 
-def test_run_sql_query(fastapi_test_client, mocker, file_db_model, setup_file_path_mock):
+def test_run_sql_query(
+    fastapi_test_client, mocker, file_db_model, setup_file_path_mock
+):
     """Test the run_sql_query endpoint."""
     setup_file_path_mock
 
@@ -358,7 +393,9 @@ def test_run_sql_query(fastapi_test_client, mocker, file_db_model, setup_file_pa
     assert response.status_code == 400
 
 
-def test_generate_query(fastapi_test_client, mocker, file_db_model, setup_file_path_mock):
+def test_generate_query(
+    fastapi_test_client, mocker, file_db_model, setup_file_path_mock
+):
     """Test the generate_sql_query endpoint."""
     setup_file_path_mock
 
@@ -372,13 +409,17 @@ def test_generate_query(fastapi_test_client, mocker, file_db_model, setup_file_p
         "table2": {"columnA": "REAL", "columnB": "BLOB"},
     }
     mock_get_active_llm = mocker.patch("api.v1.files.get_active_llm")
-    mock_get_active_llm.return_value = {"name": "test_llm", "config": {"model": "test_model"}}
+    mock_get_active_llm.return_value = {
+        "name": "test_llm",
+        "config": {"model": "test_model"},
+    }
     mock_generate_sql_query = mocker.patch("lib.duckdb_utils.generate_sql_query")
     mock_generate_sql_query.return_value = "SELECT * FROM table1 LIMIT 10;"
 
     user_request = "Get all records from table1"
     response = fastapi_test_client.post(
-        f"/files/{file_db_model.id}/sql/query/generate", json={"user_request": user_request}
+        f"/files/{file_db_model.id}/sql/query/generate",
+        json={"user_request": user_request},
     )
     assert response.status_code == 200
     assert response.json() == {
@@ -461,12 +502,14 @@ async def test_upload_files_complete(
     mock_get_folder_from_db.return_value = folder_db_model
     mock_create_file_in_db = mocker.patch("api.v1.files.create_file_in_db")
     mock_create_file_in_db.return_value = file_response
-    mock_background_tasks_add_task = mocker.patch("api.v1.files.BackgroundTasks.add_task")
-    
+    mock_background_tasks_add_task = mocker.patch(
+        "api.v1.files.BackgroundTasks.add_task"
+    )
+
     # Mock Redis
     mock_redis = mocker.patch("api.v1.files.redis_client")
     mock_redis.smembers.return_value = {b"1", b"2", b"3"}
-    
+
     resumable_identifier = "12345"
     resumable_filename = "test_file.txt"
     folder_id = folder_db_model.id
@@ -474,7 +517,7 @@ async def test_upload_files_complete(
     total_chunks = 3
     total_size = chunk_size * total_chunks
     chunk_number = 3
-    
+
     # Create dummy chunk files
     for i in range(1, total_chunks + 1):
         chunk_path = os.path.join(expected_folder_path, f"{resumable_identifier}.{i}")
@@ -527,9 +570,7 @@ def test_run_sql_query_non_sql(fastapi_test_client, mocker, file_db_model):
     assert response.json()["detail"] == "File is not a supported SQL format."
 
 
-def test_run_sql_query_limit_exceeded(
-    fastapi_test_client, mocker, file_db_model
-):
+def test_run_sql_query_limit_exceeded(fastapi_test_client, mocker, file_db_model):
     """Test run_sql_query with LIMIT exceeding max."""
     mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
     mock_get_file_from_db.return_value = file_db_model
@@ -582,7 +623,6 @@ def test_get_file_chat_history_empty(fastapi_test_client, mocker):
     }
 
 
-
 def test_get_file_chat_history_with_data(fastapi_test_client, mocker):
     """Test get_file_chat_history when chat exists."""
     mock_chat = mocker.Mock()
@@ -608,15 +648,12 @@ def test_get_file_chat_history_with_data(fastapi_test_client, mocker):
     }
 
 
-
 def test_create_file_chat_message_no_llm(fastapi_test_client, mocker):
     """Test create_file_chat_message when no LLM available."""
     mock_get_latest_file_chat_from_db = mocker.patch(
         "api.v1.files.get_latest_file_chat_from_db"
     )
-    mock_get_latest_file_chat_from_db.return_value = (
-        mocker.Mock()
-    )  # Assume chat exists
+    mock_get_latest_file_chat_from_db.return_value = mocker.Mock()  # Assume chat exists
 
     mock_get_active_llm = mocker.patch("api.v1.files.get_active_llm")
     mock_get_active_llm.return_value = None  # No active LLM
@@ -630,9 +667,7 @@ def test_create_file_chat_message_no_llm(fastapi_test_client, mocker):
 
 
 @pytest.mark.asyncio
-async def test_create_file_chat_message_success(
-    fastapi_async_test_client, mocker
-):
+async def test_create_file_chat_message_success(fastapi_async_test_client, mocker):
     """Test create_file_chat_message success."""
     mock_chat_obj = mocker.Mock()
     mock_chat_obj.id = 1
@@ -672,7 +707,3 @@ async def test_create_file_chat_message_success(
 
     assert b"This is the LLM response" in content
     assert mock_create_file_chat_message_in_db.called
-
-
-
-

--- a/src/tests/api/v1/folders_test.py
+++ b/src/tests/api/v1/folders_test.py
@@ -15,6 +15,7 @@
 """Tests for folder endpoints."""
 
 import pytest
+import httpx
 
 from datastores.sql.models.role import Role
 from datastores.sql.models.user import User as UserSQLModel
@@ -239,7 +240,23 @@ def test_get_my_folder_role(fastapi_test_client, mocker, folder_db_model):
     mock_check_user_access.assert_called_once()
 
 
+def test_get_my_folder_role_value_error(fastapi_test_client, mocker, folder_db_model):
+    """Test get_my_folder_role when check_user_access raises ValueError."""
+    mock_get_folder = mocker.patch("api.v1.folders.get_folder_from_db")
+    mock_get_folder.return_value = folder_db_model
+
+    mock_check_user_access = mocker.patch("api.v1.folders.check_user_access")
+    mock_check_user_access.side_effect = ValueError("Folder access error")
+
+    folder_id = 1
+    response = fastapi_test_client.get(f"/folders/{folder_id}/roles/me")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Folder access error"
+
+
 def test_delete_group_role(fastapi_test_client, mocker, db):
+
     mock_delete_group_role_from_db = mocker.patch(
         "api.v1.folders.delete_group_role_from_db"
     )
@@ -281,3 +298,546 @@ def test_get_folder_files(fastapi_test_client, mocker, file_response_compact_lis
     response = fastapi_test_client.get(f"/folders/{folder_id}/files/")
     assert response.status_code == 200
     assert response.json() == mock_files
+
+def test_get_folder_success(fastapi_test_client, mocker):
+    """Test get_folder returns success."""
+    import uuid
+    mock_folder = mocker.MagicMock()
+    mock_folder.is_deleted = False
+    mock_folder.id = 1
+    mock_folder.display_name = "Test Folder"
+    mock_folder.description = "Test Description"
+    mock_folder.uuid = uuid.uuid4()
+    mock_folder.parent = None
+    mock_folder.selectable = False
+    mock_folder.workflows = []
+    mock_folder.user_roles = []
+    mock_folder.group_roles = []
+    mock_folder.storage_provider = "local"
+    
+    mock_user = mocker.MagicMock()
+    mock_user.display_name = "Test User"
+    mock_user.username = "testuser"
+    mock_user.profile_picture_url = None
+    mock_user.uuid = uuid.uuid4()
+    mock_folder.user = mock_user
+
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=mock_folder)
+    
+    response = fastapi_test_client.get("/folders/1")
+    assert response.status_code == 200
+    assert response.json()["display_name"] == "Test Folder"
+
+
+def test_get_folder_not_found(fastapi_test_client, mocker):
+    """Test get_folder returns 404 when folder not found."""
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=None)
+    
+    response = fastapi_test_client.get("/folders/1")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Folder not found."
+
+
+def test_get_folder_deleted(fastapi_test_client, mocker):
+    """Test get_folder returns 404 when folder is deleted."""
+    mock_folder = mocker.MagicMock()
+    mock_folder.is_deleted = True
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=mock_folder)
+    
+    response = fastapi_test_client.get("/folders/1")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Folder is deleted."
+
+
+def test_get_folder_value_error(fastapi_test_client, mocker):
+    """Test get_folder returns 404 on ValueError."""
+    mocker.patch("api.v1.folders.get_folder_from_db", side_effect=ValueError("Invalid ID"))
+    
+    response = fastapi_test_client.get("/folders/1")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Invalid ID"
+
+
+def test_share_folder_not_found(fastapi_test_client, mocker):
+
+    """Test share_folder when folder not found."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    mock_get_folder_from_db.return_value = None
+    folder_id = 1
+
+    request = {"user_ids": [1], "user_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Folder not found."
+
+
+def test_share_folder_deleted(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when folder is deleted."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = True
+    mock_get_folder_from_db.return_value = folder_db_model
+    folder_id = 1
+
+    request = {"user_ids": [1], "user_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Cannot share a deleted folder."
+
+
+def test_share_folder_user_not_found(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when user not found."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mock_get_user_from_db = mocker.patch("api.v1.folders.get_user_from_db")
+    mock_get_user_from_db.return_value = None
+
+    folder_id = 1
+    request = {"user_ids": [999], "user_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 404
+    assert "User with ID 999 not found" in response.json()["detail"]
+def test_share_folder_invalid_role(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder with invalid role."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    folder_id = 1
+    request = {"user_ids": [1], "user_role": "INVALID_ROLE"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 400
+    assert "Invalid role provided" in response.json()["detail"]
+
+
+def test_share_folder_user_role_exists(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when user already has the role."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mock_get_user_from_db = mocker.patch("api.v1.folders.get_user_from_db")
+    mock_get_user_from_db.return_value = mocker.MagicMock()
+
+    mock_user_role_exists = mocker.patch("api.v1.folders.user_role_exists")
+    mock_user_role_exists.return_value = True
+
+    folder_id = 1
+    request = {"user_ids": [1], "user_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 409
+    assert "already has the role" in response.json()["detail"]
+
+
+def test_share_folder_username_not_found(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when user by username not found."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mock_get_user_by_username = mocker.patch("api.v1.folders.get_user_by_username_from_db")
+    mock_get_user_by_username.return_value = None
+
+    folder_id = 1
+    request = {"user_names": ["nonexistent"], "user_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 404
+    assert "User with username 'nonexistent' not found" in response.json()["detail"]
+
+
+def test_share_folder_username_role_exists(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when user by username already has the role."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mock_user = mocker.MagicMock()
+    mock_user.id = 1
+    mock_get_user_by_username = mocker.patch("api.v1.folders.get_user_by_username_from_db")
+    mock_get_user_by_username.return_value = mock_user
+
+    mock_user_role_exists = mocker.patch("api.v1.folders.user_role_exists")
+    mock_user_role_exists.return_value = True
+
+    folder_id = 1
+    request = {"user_names": ["testuser"], "user_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 409
+    assert "already has the role" in response.json()["detail"]
+
+
+def test_share_folder_group_not_found(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when group not found."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mock_get_group_from_db = mocker.patch("api.v1.folders.get_group_from_db")
+    mock_get_group_from_db.return_value = None
+
+    folder_id = 1
+    request = {"group_ids": [999], "group_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 404
+    assert "Group with ID 999 not found" in response.json()["detail"]
+
+
+def test_share_folder_group_role_exists(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when group already has the role."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mock_get_group_from_db = mocker.patch("api.v1.folders.get_group_from_db")
+    mock_get_group_from_db.return_value = mocker.MagicMock()
+
+    mock_group_role_exists = mocker.patch("api.v1.folders.group_role_exists")
+    mock_group_role_exists.return_value = True
+
+    folder_id = 1
+    request = {"group_ids": [1], "group_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 409
+    assert "already has the role" in response.json()["detail"]
+
+
+def test_share_folder_group_by_name_not_found(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when group by name not found."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mock_get_group_by_name = mocker.patch("api.v1.folders.get_group_by_name_from_db")
+    mock_get_group_by_name.return_value = None
+
+    folder_id = 1
+    request = {"group_names": ["nonexistent"], "group_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 404
+    assert "Group with name 'nonexistent' not found" in response.json()["detail"]
+
+
+def test_share_folder_group_by_name_role_exists(fastapi_test_client, mocker, folder_db_model):
+    """Test share_folder when group by name already has the role."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mock_group = mocker.MagicMock()
+    mock_group.id = 1
+    mock_get_group_by_name = mocker.patch("api.v1.folders.get_group_by_name_from_db")
+    mock_get_group_by_name.return_value = mock_group
+
+    mock_group_role_exists = mocker.patch("api.v1.folders.group_role_exists")
+    mock_group_role_exists.return_value = True
+
+    folder_id = 1
+    request = {"group_names": ["testgroup"], "group_role": "Viewer"}
+    response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
+    assert response.status_code == 409
+    assert "already has the role" in response.json()["detail"]
+
+
+def test_start_investigation_no_adk_url(fastapi_test_client, mocker, folder_db_model):
+
+
+
+    """Test start_investigation when ADK URL is not configured."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    # Mock config.config
+    mocker.patch("api.v1.folders.config.config", {})  # Empty dict
+
+    folder_id = 1
+    request_data = {
+        "session_id": "test_session",
+        "agent_name": "test_agent",
+        "user_message": "test question",
+    }
+    response = fastapi_test_client.post(
+        f"/folders/{folder_id}/investigations/run", json=request_data
+    )
+    assert response.status_code == 503
+    assert response.json()["detail"] == "ADK server URL is not configured."
+
+
+@pytest.mark.asyncio
+async def test_start_investigation_success(fastapi_async_test_client, mocker, folder_db_model):
+    """Test start_investigation success."""
+    mock_get_folder = mocker.patch("api.v1.folders.get_folder_from_db")
+    mock_get_folder.return_value = folder_db_model
+    
+    # Mock config
+    mocker.patch("api.v1.folders.config.config", {"experiments": {"agents": {"adk_server_url": "http://mock-adk"}}})
+    
+    # Mock stream manager
+    mock_stream_manager = mocker.patch("api.v1.folders.stream_manager")
+    mock_session = mocker.MagicMock()
+    mock_stream_manager.get_session.return_value = None # New session
+    mock_stream_manager.create_session.return_value = mock_session
+    
+    # Mock httpx.AsyncClient
+    mock_async_client = mocker.patch("api.v1.folders.httpx.AsyncClient")
+    mock_client_instance = mocker.MagicMock()
+    mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+    
+    mock_response = mocker.MagicMock()
+    mock_response.raise_for_status.return_value = None
+    
+    # Mock async iterator for response.aiter_bytes()
+    async def mock_aiter_bytes():
+        yield b"data: {\"type\": \"message\", \"message\": \"hello\"}\n"
+        yield b"data: {\"type\": \"complete\", \"message\": \"done\"}\n"
+        
+    mock_response.aiter_bytes.return_value = mock_aiter_bytes()
+    
+    # Mock the context manager for client.stream
+    class MockStreamContextManager:
+        async def __aenter__(self):
+            return mock_response
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            pass
+            
+    mock_client_instance.stream.return_value = MockStreamContextManager()
+
+    folder_id = 1
+    request_data = {
+        "session_id": "test_session",
+        "agent_name": "test_agent",
+        "user_message": "test question",
+    }
+    
+    response = await fastapi_async_test_client.post(
+        f"/folders/{folder_id}/investigations/run", json=request_data
+    )
+    
+    assert response.status_code == 200
+
+
+
+def test_create_adk_session_no_adk_url(fastapi_test_client, mocker, folder_db_model):
+    """Test create_adk_session when ADK URL is not configured."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    # Mock config.config
+    mocker.patch("api.v1.folders.config.config", {})  # Empty dict
+
+    folder_id = 1
+    request_data = {"context": "test context"}
+    response = fastapi_test_client.post(
+        f"/folders/{folder_id}/investigations/init", json=request_data
+    )
+    assert response.status_code == 503
+    assert response.json()["detail"] == "ADK server URL is not configured."
+
+
+@pytest.mark.asyncio
+async def test_create_adk_session_success(
+    fastapi_async_test_client, mocker, folder_db_model
+):
+    """Test create_adk_session success."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mocker.patch(
+        "api.v1.folders.config.config",
+        {"experiments": {"agents": {"adk_server_url": "http://mock-adk"}}},
+    )
+
+    class MockFile:
+
+        def __init__(self, display_name, magic_mime, magic_text):
+            self.display_name = display_name
+            self.magic_mime = magic_mime
+            self.magic_text = magic_text
+
+    mocker.patch(
+        "api.v1.folders.get_files_from_db",
+        return_value=[MockFile("test.txt", "text/plain", "ASCII text")],
+    )
+
+    mock_payload = mocker.MagicMock()
+    mock_payload.dict.return_value = {"initial": "state"}
+    mocker.patch("api.v1.folders.generate_initial_state", return_value=mock_payload)
+
+    mock_response = mocker.MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status.return_value = None
+    mocker.patch("api.v1.folders.httpx.post", return_value=mock_response)
+
+    import uuid
+
+    mock_uuid_obj = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    mock_uuid = mocker.patch("api.v1.folders.uuid.uuid4")
+    mock_uuid.return_value = mock_uuid_obj
+
+    folder_id = 1
+    request_data = {"context": "test context"}
+    response = await fastapi_async_test_client.post(
+        f"/folders/{folder_id}/investigations/init", json=request_data
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
+    )
+
+
+def test_get_all_folders(fastapi_test_client, mocker, folder_response_compact):
+    """Test getting all folders."""
+    mock_folders = [
+        folder_response_compact.model_dump(mode="json"),
+        folder_response_compact.model_dump(mode="json"),
+    ]
+    mock_get_all_folders_from_db = mocker.patch(
+        "api.v1.folders.get_all_folders_from_db"
+    )
+    mock_get_all_folders_from_db.return_value = (mock_folders, 2)
+
+    response = fastapi_test_client.get("/folders/all/")
+    assert response.status_code == 200
+    assert response.json()["folders"] == mock_folders
+    assert response.json()["total_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_create_adk_session_status_error(
+    fastapi_async_test_client, mocker, folder_db_model
+):
+    """Test create_adk_session with HTTPStatusError."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mocker.patch(
+        "api.v1.folders.config.config",
+        {"experiments": {"agents": {"adk_server_url": "http://mock-adk"}}},
+    )
+    mocker.patch("api.v1.folders.get_files_from_db", return_value=[])
+
+    mock_payload = mocker.MagicMock()
+    mock_payload.dict.return_value = {"initial": "state"}
+    mocker.patch("api.v1.folders.generate_initial_state", return_value=mock_payload)
+
+    def raise_status_error(*args, **kwargs):
+        mock_resp = mocker.MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "Internal Error"
+        raise httpx.HTTPStatusError(
+            "Mock error", request=mocker.MagicMock(), response=mock_resp
+        )
+
+    mocker.patch("api.v1.folders.httpx.post", side_effect=raise_status_error)
+
+    import uuid
+
+    mock_uuid_obj = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    mocker.patch("api.v1.folders.uuid.uuid4", return_value=mock_uuid_obj)
+
+    folder_id = 1
+    request_data = {"context": "test context"}
+    response = await fastapi_async_test_client.post(
+        f"/folders/{folder_id}/investigations/init", json=request_data
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_adk_session_request_error(
+    fastapi_async_test_client, mocker, folder_db_model
+):
+    """Test create_adk_session with RequestError."""
+    mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
+    folder_db_model.is_deleted = False
+    mock_get_folder_from_db.return_value = folder_db_model
+
+    mocker.patch(
+        "api.v1.folders.config.config",
+        {"experiments": {"agents": {"adk_server_url": "http://mock-adk"}}},
+    )
+    mocker.patch("api.v1.folders.get_files_from_db", return_value=[])
+
+    mock_payload = mocker.MagicMock()
+    mock_payload.dict.return_value = {"initial": "state"}
+    mocker.patch("api.v1.folders.generate_initial_state", return_value=mock_payload)
+
+    def raise_request_error(*args, **kwargs):
+        raise httpx.RequestError("Connection failed", request=mocker.MagicMock())
+
+    mocker.patch("api.v1.folders.httpx.post", side_effect=raise_request_error)
+
+    import uuid
+
+    mock_uuid_obj = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    mocker.patch("api.v1.folders.uuid.uuid4", return_value=mock_uuid_obj)
+
+    folder_id = 1
+    request_data = {"context": "test context"}
+    response = await fastapi_async_test_client.post(
+        f"/folders/{folder_id}/investigations/init", json=request_data
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
+    )
+@pytest.mark.asyncio
+async def test_get_adk_sse_session_success(mocker):
+    """Test get_adk_sse_session success by calling it directly."""
+    from api.v1.folders import get_adk_sse_session
+    
+    mocker.patch(
+        "api.v1.folders.config.config",
+        {"experiments": {"agents": {"adk_server_url": "http://mock-adk"}}},
+    )
+    
+    # Mock sleep to not wait
+    mocker.patch("api.v1.folders.asyncio.sleep", return_value=None)
+    
+    mock_async_client = mocker.patch("api.v1.folders.httpx.AsyncClient")
+    mock_client_instance = mocker.AsyncMock()
+    mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+    
+    mock_response = mocker.MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"status": "running"}
+    
+    # First call succeeds, second raises RequestError to break loop
+    mock_client_instance.get.side_effect = [
+        mock_response,
+        httpx.RequestError("Connection failed", request=mocker.MagicMock())
+    ]
+
+    # Mock dependencies
+    mock_db = mocker.MagicMock()
+    mock_user = mocker.MagicMock()
+    mock_user.id = 1
+    
+    response = await get_adk_sse_session(
+        folder_id=1,
+        session_id="test_session",
+        db=mock_db,
+        current_user=mock_user
+    )
+    
+    # response is an EventSourceResponse
+    # We can iterate over its body_iterator
+    results = []
+    try:
+        async for item in response.body_iterator:
+            results.append(item)
+    except Exception:
+        pass
+        
+    assert len(results) > 0
+    assert "running" in results[0]
+
+

--- a/src/tests/api/v1/folders_test.py
+++ b/src/tests/api/v1/folders_test.py
@@ -69,8 +69,7 @@ def test_get_subfolders(fastapi_test_client, mocker, folder_response_compact):
 
 @pytest.mark.asyncio
 async def test_create_root_folder(fastapi_async_test_client, mocker, folder_response):
-    mock_folder_create = mocker.patch(
-        "api.v1.folders.create_root_folder_in_db")
+    mock_folder_create = mocker.patch("api.v1.folders.create_root_folder_in_db")
     mock_folder_create.return_value = folder_response
     request = {"display_name": "test folder"}
     response = await fastapi_async_test_client.post("/folders/", json=request)
@@ -82,8 +81,7 @@ async def test_create_root_folder(fastapi_async_test_client, mocker, folder_resp
 async def test_create_subfolder(fastapi_async_test_client, mocker, folder_response):
     """Test create subfolder route."""
     parent_folder_id = 1
-    mock_create_subfolder = mocker.patch(
-        "api.v1.folders.create_subfolder_in_db")
+    mock_create_subfolder = mocker.patch("api.v1.folders.create_subfolder_in_db")
     folder_response.display_name = "test subfolder"
     mock_create_subfolder.return_value = folder_response
     request = {"display_name": "test subfolder"}
@@ -124,7 +122,9 @@ def test_delete_folder(fastapi_test_client, mocker, db):
     mock_delete_folder.assert_called_once_with(db, folder_id)
 
 
-def test_share_folder(fastapi_test_client, mocker, db, folder_db_model, folder_response):
+def test_share_folder(
+    fastapi_test_client, mocker, db, folder_db_model, folder_response
+):
     folder_id = 1
     mock_get_folder_db = mocker.patch("api.v1.folders.get_folder_from_db")
     folder_db_model.id = folder_id  # Ensure the fixture's ID matches
@@ -136,10 +136,8 @@ def test_share_folder(fastapi_test_client, mocker, db, folder_db_model, folder_r
     mock_user_role_exists.return_value = False
     mock_user_1 = mocker.MagicMock(spec=UserSQLModel, id=1, username="user1")
     mock_user_2 = mocker.MagicMock(spec=UserSQLModel, id=2, username="user2")
-    mock_user_admin = mocker.MagicMock(
-        spec=UserSQLModel, id=10, username="admin")
-    mock_user_test = mocker.MagicMock(
-        spec=UserSQLModel, id=11, username="test")
+    mock_user_admin = mocker.MagicMock(spec=UserSQLModel, id=10, username="admin")
+    mock_user_test = mocker.MagicMock(spec=UserSQLModel, id=11, username="test")
 
     mock_get_user_from_db = mocker.patch("api.v1.folders.get_user_from_db")
     mock_get_user_from_db.side_effect = lambda db_session, user_id_val: {
@@ -157,10 +155,10 @@ def test_share_folder(fastapi_test_client, mocker, db, folder_db_model, folder_r
 
     mock_group_3 = mocker.MagicMock(spec=GroupSQLModel, id=3, name="group3")
     mock_group_4 = mocker.MagicMock(spec=GroupSQLModel, id=4, name="group4")
-    mock_group_everyone = mocker.MagicMock(
-        spec=GroupSQLModel, id=20, name="Everyone")
+    mock_group_everyone = mocker.MagicMock(spec=GroupSQLModel, id=20, name="Everyone")
     mock_group_test_group = mocker.MagicMock(
-        spec=GroupSQLModel, id=21, name="test_group")
+        spec=GroupSQLModel, id=21, name="test_group"
+    )
 
     mock_get_group_from_db = mocker.patch("api.v1.folders.get_group_from_db")
     mock_get_group_from_db.side_effect = lambda db_session, group_id_val: {
@@ -181,10 +179,8 @@ def test_share_folder(fastapi_test_client, mocker, db, folder_db_model, folder_r
     mocker.patch("api.v1.folders.group_role_exists", return_value=False)
 
     # 4. Mock role creation functions (already in the original test)
-    mock_create_user_role = mocker.patch(
-        "api.v1.folders.create_user_role_in_db")
-    mock_create_group_role = mocker.patch(
-        "api.v1.folders.create_group_role_in_db")
+    mock_create_user_role = mocker.patch("api.v1.folders.create_user_role_in_db")
+    mock_create_group_role = mocker.patch("api.v1.folders.create_group_role_in_db")
 
     request = schemas.FolderShareRequest(
         user_ids=[1, 2],
@@ -204,24 +200,32 @@ def test_share_folder(fastapi_test_client, mocker, db, folder_db_model, folder_r
 
     # Assert that create_user_role_in_db was called correctly
     mock_create_user_role.assert_any_call(
-        db, Role.EDITOR.name, mock_user_1.id, folder_id=folder_id)
+        db, Role.EDITOR.name, mock_user_1.id, folder_id=folder_id
+    )
     mock_create_user_role.assert_any_call(
-        db, Role.EDITOR.name, mock_user_2.id, folder_id=folder_id)
+        db, Role.EDITOR.name, mock_user_2.id, folder_id=folder_id
+    )
     mock_create_user_role.assert_any_call(
-        db, Role.EDITOR.name, mock_user_admin.id, folder_id=folder_id)
+        db, Role.EDITOR.name, mock_user_admin.id, folder_id=folder_id
+    )
     mock_create_user_role.assert_any_call(
-        db, Role.EDITOR.name, mock_user_test.id, folder_id=folder_id)
+        db, Role.EDITOR.name, mock_user_test.id, folder_id=folder_id
+    )
     assert mock_create_user_role.call_count == 4
 
     # Assert that create_group_role_in_db was called correctly
     mock_create_group_role.assert_any_call(
-        db, Role.VIEWER.name, mock_group_3.id, folder_id=folder_id)
+        db, Role.VIEWER.name, mock_group_3.id, folder_id=folder_id
+    )
     mock_create_group_role.assert_any_call(
-        db, Role.VIEWER.name, mock_group_4.id, folder_id=folder_id)
+        db, Role.VIEWER.name, mock_group_4.id, folder_id=folder_id
+    )
     mock_create_group_role.assert_any_call(
-        db, Role.VIEWER.name, mock_group_everyone.id, folder_id=folder_id)
+        db, Role.VIEWER.name, mock_group_everyone.id, folder_id=folder_id
+    )
     mock_create_group_role.assert_any_call(
-        db, Role.VIEWER.name, mock_group_test_group.id, folder_id=folder_id)
+        db, Role.VIEWER.name, mock_group_test_group.id, folder_id=folder_id
+    )
     assert mock_create_group_role.call_count == 4
 
 
@@ -278,8 +282,7 @@ def test_delete_user_role(fastapi_test_client, mocker, db):
     folder_id = 1
     role_id = 2
 
-    response = fastapi_test_client.delete(
-        f"/folders/{folder_id}/roles/users/{role_id}")
+    response = fastapi_test_client.delete(f"/folders/{folder_id}/roles/users/{role_id}")
 
     assert response.status_code == 200
     mock_delete_user_role_from_db.assert_called_once_with(db, role_id)
@@ -299,9 +302,11 @@ def test_get_folder_files(fastapi_test_client, mocker, file_response_compact_lis
     assert response.status_code == 200
     assert response.json() == mock_files
 
+
 def test_get_folder_success(fastapi_test_client, mocker):
     """Test get_folder returns success."""
     import uuid
+
     mock_folder = mocker.MagicMock()
     mock_folder.is_deleted = False
     mock_folder.id = 1
@@ -314,7 +319,7 @@ def test_get_folder_success(fastapi_test_client, mocker):
     mock_folder.user_roles = []
     mock_folder.group_roles = []
     mock_folder.storage_provider = "local"
-    
+
     mock_user = mocker.MagicMock()
     mock_user.display_name = "Test User"
     mock_user.username = "testuser"
@@ -323,7 +328,7 @@ def test_get_folder_success(fastapi_test_client, mocker):
     mock_folder.user = mock_user
 
     mocker.patch("api.v1.folders.get_folder_from_db", return_value=mock_folder)
-    
+
     response = fastapi_test_client.get("/folders/1")
     assert response.status_code == 200
     assert response.json()["display_name"] == "Test Folder"
@@ -332,7 +337,7 @@ def test_get_folder_success(fastapi_test_client, mocker):
 def test_get_folder_not_found(fastapi_test_client, mocker):
     """Test get_folder returns 404 when folder not found."""
     mocker.patch("api.v1.folders.get_folder_from_db", return_value=None)
-    
+
     response = fastapi_test_client.get("/folders/1")
     assert response.status_code == 404
     assert response.json()["detail"] == "Folder not found."
@@ -343,7 +348,7 @@ def test_get_folder_deleted(fastapi_test_client, mocker):
     mock_folder = mocker.MagicMock()
     mock_folder.is_deleted = True
     mocker.patch("api.v1.folders.get_folder_from_db", return_value=mock_folder)
-    
+
     response = fastapi_test_client.get("/folders/1")
     assert response.status_code == 404
     assert response.json()["detail"] == "Folder is deleted."
@@ -351,15 +356,16 @@ def test_get_folder_deleted(fastapi_test_client, mocker):
 
 def test_get_folder_value_error(fastapi_test_client, mocker):
     """Test get_folder returns 404 on ValueError."""
-    mocker.patch("api.v1.folders.get_folder_from_db", side_effect=ValueError("Invalid ID"))
-    
+    mocker.patch(
+        "api.v1.folders.get_folder_from_db", side_effect=ValueError("Invalid ID")
+    )
+
     response = fastapi_test_client.get("/folders/1")
     assert response.status_code == 404
     assert response.json()["detail"] == "Invalid ID"
 
 
 def test_share_folder_not_found(fastapi_test_client, mocker):
-
     """Test share_folder when folder not found."""
     mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
     mock_get_folder_from_db.return_value = None
@@ -398,6 +404,8 @@ def test_share_folder_user_not_found(fastapi_test_client, mocker, folder_db_mode
     response = fastapi_test_client.post(f"/folders/{folder_id}/roles", json=request)
     assert response.status_code == 404
     assert "User with ID 999 not found" in response.json()["detail"]
+
+
 def test_share_folder_invalid_role(fastapi_test_client, mocker, folder_db_model):
     """Test share_folder with invalid role."""
     mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
@@ -436,7 +444,9 @@ def test_share_folder_username_not_found(fastapi_test_client, mocker, folder_db_
     folder_db_model.is_deleted = False
     mock_get_folder_from_db.return_value = folder_db_model
 
-    mock_get_user_by_username = mocker.patch("api.v1.folders.get_user_by_username_from_db")
+    mock_get_user_by_username = mocker.patch(
+        "api.v1.folders.get_user_by_username_from_db"
+    )
     mock_get_user_by_username.return_value = None
 
     folder_id = 1
@@ -446,7 +456,9 @@ def test_share_folder_username_not_found(fastapi_test_client, mocker, folder_db_
     assert "User with username 'nonexistent' not found" in response.json()["detail"]
 
 
-def test_share_folder_username_role_exists(fastapi_test_client, mocker, folder_db_model):
+def test_share_folder_username_role_exists(
+    fastapi_test_client, mocker, folder_db_model
+):
     """Test share_folder when user by username already has the role."""
     mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
     folder_db_model.is_deleted = False
@@ -454,7 +466,9 @@ def test_share_folder_username_role_exists(fastapi_test_client, mocker, folder_d
 
     mock_user = mocker.MagicMock()
     mock_user.id = 1
-    mock_get_user_by_username = mocker.patch("api.v1.folders.get_user_by_username_from_db")
+    mock_get_user_by_username = mocker.patch(
+        "api.v1.folders.get_user_by_username_from_db"
+    )
     mock_get_user_by_username.return_value = mock_user
 
     mock_user_role_exists = mocker.patch("api.v1.folders.user_role_exists")
@@ -502,7 +516,9 @@ def test_share_folder_group_role_exists(fastapi_test_client, mocker, folder_db_m
     assert "already has the role" in response.json()["detail"]
 
 
-def test_share_folder_group_by_name_not_found(fastapi_test_client, mocker, folder_db_model):
+def test_share_folder_group_by_name_not_found(
+    fastapi_test_client, mocker, folder_db_model
+):
     """Test share_folder when group by name not found."""
     mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
     folder_db_model.is_deleted = False
@@ -518,7 +534,9 @@ def test_share_folder_group_by_name_not_found(fastapi_test_client, mocker, folde
     assert "Group with name 'nonexistent' not found" in response.json()["detail"]
 
 
-def test_share_folder_group_by_name_role_exists(fastapi_test_client, mocker, folder_db_model):
+def test_share_folder_group_by_name_role_exists(
+    fastapi_test_client, mocker, folder_db_model
+):
     """Test share_folder when group by name already has the role."""
     mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
     folder_db_model.is_deleted = False
@@ -540,9 +558,6 @@ def test_share_folder_group_by_name_role_exists(fastapi_test_client, mocker, fol
 
 
 def test_start_investigation_no_adk_url(fastapi_test_client, mocker, folder_db_model):
-
-
-
     """Test start_investigation when ADK URL is not configured."""
     mock_get_folder_from_db = mocker.patch("api.v1.folders.get_folder_from_db")
     mock_get_folder_from_db.return_value = folder_db_model
@@ -564,42 +579,48 @@ def test_start_investigation_no_adk_url(fastapi_test_client, mocker, folder_db_m
 
 
 @pytest.mark.asyncio
-async def test_start_investigation_success(fastapi_async_test_client, mocker, folder_db_model):
+async def test_start_investigation_success(
+    fastapi_async_test_client, mocker, folder_db_model
+):
     """Test start_investigation success."""
     mock_get_folder = mocker.patch("api.v1.folders.get_folder_from_db")
     mock_get_folder.return_value = folder_db_model
-    
+
     # Mock config
-    mocker.patch("api.v1.folders.config.config", {"experiments": {"agents": {"adk_server_url": "http://mock-adk"}}})
-    
+    mocker.patch(
+        "api.v1.folders.config.config",
+        {"experiments": {"agents": {"adk_server_url": "http://mock-adk"}}},
+    )
+
     # Mock stream manager
     mock_stream_manager = mocker.patch("api.v1.folders.stream_manager")
     mock_session = mocker.MagicMock()
-    mock_stream_manager.get_session.return_value = None # New session
+    mock_stream_manager.get_session.return_value = None  # New session
     mock_stream_manager.create_session.return_value = mock_session
-    
+
     # Mock httpx.AsyncClient
     mock_async_client = mocker.patch("api.v1.folders.httpx.AsyncClient")
     mock_client_instance = mocker.MagicMock()
     mock_async_client.return_value.__aenter__.return_value = mock_client_instance
-    
+
     mock_response = mocker.MagicMock()
     mock_response.raise_for_status.return_value = None
-    
+
     # Mock async iterator for response.aiter_bytes()
     async def mock_aiter_bytes():
-        yield b"data: {\"type\": \"message\", \"message\": \"hello\"}\n"
-        yield b"data: {\"type\": \"complete\", \"message\": \"done\"}\n"
-        
+        yield b'data: {"type": "message", "message": "hello"}\n'
+        yield b'data: {"type": "complete", "message": "done"}\n'
+
     mock_response.aiter_bytes.return_value = mock_aiter_bytes()
-    
+
     # Mock the context manager for client.stream
     class MockStreamContextManager:
         async def __aenter__(self):
             return mock_response
+
         async def __aexit__(self, exc_type, exc_val, exc_tb):
             pass
-            
+
     mock_client_instance.stream.return_value = MockStreamContextManager()
 
     folder_id = 1
@@ -608,13 +629,12 @@ async def test_start_investigation_success(fastapi_async_test_client, mocker, fo
         "agent_name": "test_agent",
         "user_message": "test question",
     }
-    
+
     response = await fastapi_async_test_client.post(
         f"/folders/{folder_id}/investigations/run", json=request_data
     )
-    
-    assert response.status_code == 200
 
+    assert response.status_code == 200
 
 
 def test_create_adk_session_no_adk_url(fastapi_test_client, mocker, folder_db_model):
@@ -682,9 +702,7 @@ async def test_create_adk_session_success(
     )
 
     assert response.status_code == 200
-    assert (
-        response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
-    )
+    assert response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
 
 
 def test_get_all_folders(fastapi_test_client, mocker, folder_response_compact):
@@ -745,9 +763,7 @@ async def test_create_adk_session_status_error(
     )
 
     assert response.status_code == 200
-    assert (
-        response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
-    )
+    assert response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
 
 
 @pytest.mark.asyncio
@@ -786,48 +802,45 @@ async def test_create_adk_session_request_error(
     )
 
     assert response.status_code == 200
-    assert (
-        response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
-    )
+    assert response.json()["session_id"] == "12345678-1234-5678-1234-567812345678"
+
+
 @pytest.mark.asyncio
 async def test_get_adk_sse_session_success(mocker):
     """Test get_adk_sse_session success by calling it directly."""
     from api.v1.folders import get_adk_sse_session
-    
+
     mocker.patch(
         "api.v1.folders.config.config",
         {"experiments": {"agents": {"adk_server_url": "http://mock-adk"}}},
     )
-    
+
     # Mock sleep to not wait
     mocker.patch("api.v1.folders.asyncio.sleep", return_value=None)
-    
+
     mock_async_client = mocker.patch("api.v1.folders.httpx.AsyncClient")
     mock_client_instance = mocker.AsyncMock()
     mock_async_client.return_value.__aenter__.return_value = mock_client_instance
-    
+
     mock_response = mocker.MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.json.return_value = {"status": "running"}
-    
+
     # First call succeeds, second raises RequestError to break loop
     mock_client_instance.get.side_effect = [
         mock_response,
-        httpx.RequestError("Connection failed", request=mocker.MagicMock())
+        httpx.RequestError("Connection failed", request=mocker.MagicMock()),
     ]
 
     # Mock dependencies
     mock_db = mocker.MagicMock()
     mock_user = mocker.MagicMock()
     mock_user.id = 1
-    
+
     response = await get_adk_sse_session(
-        folder_id=1,
-        session_id="test_session",
-        db=mock_db,
-        current_user=mock_user
+        folder_id=1, session_id="test_session", db=mock_db, current_user=mock_user
     )
-    
+
     # response is an EventSourceResponse
     # We can iterate over its body_iterator
     results = []
@@ -836,8 +849,6 @@ async def test_get_adk_sse_session_success(mocker):
             results.append(item)
     except Exception:
         pass
-        
+
     assert len(results) > 0
     assert "running" in results[0]
-
-

--- a/src/tests/api/v1/groups_test.py
+++ b/src/tests/api/v1/groups_test.py
@@ -189,7 +189,9 @@ def test_get_group_users_not_found(fastapi_test_client, db):
 def test_add_users_to_group(fastapi_test_client, db, example_groups, mocker):
     """Test the add_users_to_group endpoint."""
     mock_group = example_groups[0]
-    mock_group.users = mocker.MagicMock(spec=list)  # Ensure users attribute is a mock list
+    mock_group.users = mocker.MagicMock(
+        spec=list
+    )  # Ensure users attribute is a mock list
 
     # Mock users to be added - these need full attributes for UserResponse
     mock_user_to_add_1 = mocker.MagicMock(spec=UserSQLModel)
@@ -461,7 +463,9 @@ def test_remove_users_from_group_user_not_in_group(
         if model.__name__ == "Group":
             return mocker.MagicMock(
                 filter=mocker.MagicMock(
-                    return_value=mocker.MagicMock(first=mocker.MagicMock(return_value=mock_group))
+                    return_value=mocker.MagicMock(
+                        first=mocker.MagicMock(return_value=mock_group)
+                    )
                 )
             )
         elif model.__name__ == "User":

--- a/src/tests/api/v1/groups_test.py
+++ b/src/tests/api/v1/groups_test.py
@@ -16,7 +16,7 @@
 import uuid
 from datastores.sql.models.group import Group as GroupSQLModel  # Import Group model
 import json
-from unittest.mock import MagicMock
+
 
 from datastores.sql.models.user import User as UserSQLModel
 
@@ -43,23 +43,23 @@ def test_create_group_with_users(fastapi_test_client, db, mocker):
     # db.query.return_value.filter.return_value.first.return_value = None
 
     # Mock the user lookups within create_group_in_db and add_users_to_group
-    mock_user_test = MagicMock(spec=UserSQLModel)
+    mock_user_test = mocker.MagicMock(spec=UserSQLModel)
     mock_user_test.username = "test"
-    mock_user_test_groups_collection = MagicMock(spec=list)
+    mock_user_test_groups_collection = mocker.MagicMock(spec=list)
     mock_user_test.groups = mock_user_test_groups_collection
-    mock_user_test._sa_instance_state = MagicMock()
+    mock_user_test._sa_instance_state = mocker.MagicMock()
     mock_user_test._sa_instance_state.manager.initialize_collection.return_value = (
-        MagicMock(),
+        mocker.MagicMock(),
         mock_user_test_groups_collection,
     )
 
-    mock_user_test2 = MagicMock(spec=UserSQLModel)
+    mock_user_test2 = mocker.MagicMock(spec=UserSQLModel)
     mock_user_test2.username = "test2"
-    mock_user_test2_groups_collection = MagicMock(spec=list)
+    mock_user_test2_groups_collection = mocker.MagicMock(spec=list)
     mock_user_test2.groups = mock_user_test2_groups_collection
-    mock_user_test2._sa_instance_state = MagicMock()
+    mock_user_test2._sa_instance_state = mocker.MagicMock()
     mock_user_test2._sa_instance_state.manager.initialize_collection.return_value = (
-        MagicMock(),
+        mocker.MagicMock(),
         mock_user_test2_groups_collection,
     )
 
@@ -73,16 +73,16 @@ def test_create_group_with_users(fastapi_test_client, db, mocker):
 
     def query_side_effect(model):
         if model.__name__ == "Group":
-            mock_group_query = MagicMock()
+            mock_group_query = mocker.MagicMock()
             mock_group_query.filter.return_value.first.return_value = (
                 None  # No existing group
             )
             return mock_group_query
         elif model.__name__ == "User":
-            mock_user_query = MagicMock()
+            mock_user_query = mocker.MagicMock()
             # Simulate filter by username: User.username == value
-            mock_user_query.filter.side_effect = lambda expr: MagicMock(
-                first=MagicMock(
+            mock_user_query.filter.side_effect = lambda expr: mocker.MagicMock(
+                first=mocker.MagicMock(
                     return_value=mock_user_query_result.get(expr.right.value)
                 )
             )
@@ -189,10 +189,10 @@ def test_get_group_users_not_found(fastapi_test_client, db):
 def test_add_users_to_group(fastapi_test_client, db, example_groups, mocker):
     """Test the add_users_to_group endpoint."""
     mock_group = example_groups[0]
-    mock_group.users = MagicMock(spec=list)  # Ensure users attribute is a mock list
+    mock_group.users = mocker.MagicMock(spec=list)  # Ensure users attribute is a mock list
 
     # Mock users to be added - these need full attributes for UserResponse
-    mock_user_to_add_1 = MagicMock(spec=UserSQLModel)
+    mock_user_to_add_1 = mocker.MagicMock(spec=UserSQLModel)
     mock_user_to_add_1.id = 101
     mock_user_to_add_1.display_name = "Added User 1"
     mock_user_to_add_1.username = "added_user1_uname"
@@ -201,15 +201,15 @@ def test_add_users_to_group(fastapi_test_client, db, example_groups, mocker):
     mock_user_to_add_1.profile_picture_url = None
     mock_user_to_add_1.uuid = uuid.uuid4()
     mock_user_to_add_1.is_admin = False
-    mock_user_to_add_1_groups_collection = MagicMock(spec=list)
+    mock_user_to_add_1_groups_collection = mocker.MagicMock(spec=list)
     mock_user_to_add_1.groups = mock_user_to_add_1_groups_collection
-    mock_user_to_add_1._sa_instance_state = MagicMock()
+    mock_user_to_add_1._sa_instance_state = mocker.MagicMock()
     mock_user_to_add_1._sa_instance_state.manager.initialize_collection.return_value = (
-        MagicMock(),
+        mocker.MagicMock(),
         mock_user_to_add_1_groups_collection,
     )
 
-    mock_user_to_add_2 = MagicMock(spec=UserSQLModel)
+    mock_user_to_add_2 = mocker.MagicMock(spec=UserSQLModel)
     mock_user_to_add_2.id = 102
     mock_user_to_add_2.display_name = "Added User 2"
     mock_user_to_add_2.username = "added_user2_uname"
@@ -218,11 +218,11 @@ def test_add_users_to_group(fastapi_test_client, db, example_groups, mocker):
     mock_user_to_add_2.profile_picture_url = None
     mock_user_to_add_2.uuid = uuid.uuid4()
     mock_user_to_add_2.is_admin = False
-    mock_user_to_add_2_groups_collection = MagicMock(spec=list)
+    mock_user_to_add_2_groups_collection = mocker.MagicMock(spec=list)
     mock_user_to_add_2.groups = mock_user_to_add_2_groups_collection
-    mock_user_to_add_2._sa_instance_state = MagicMock()
+    mock_user_to_add_2._sa_instance_state = mocker.MagicMock()
     mock_user_to_add_2._sa_instance_state.manager.initialize_collection.return_value = (
-        MagicMock(),
+        mocker.MagicMock(),
         mock_user_to_add_2_groups_collection,
     )
 
@@ -235,13 +235,13 @@ def test_add_users_to_group(fastapi_test_client, db, example_groups, mocker):
 
     def query_side_effect(model):
         if model.__name__ == "Group":
-            mock_group_query = MagicMock()
+            mock_group_query = mocker.MagicMock()
             mock_group_query.filter.return_value.first.return_value = mock_group
             return mock_group_query
         elif model.__name__ == "User":
-            mock_user_query = MagicMock()
-            mock_user_query.filter.side_effect = lambda expr: MagicMock(
-                first=MagicMock(
+            mock_user_query = mocker.MagicMock()
+            mock_user_query.filter.side_effect = lambda expr: mocker.MagicMock(
+                first=mocker.MagicMock(
                     return_value=mock_user_query_results.get(expr.right.value)
                 )
             )
@@ -283,13 +283,13 @@ def test_add_users_to_group_with_nonexistent_user(
     mock_group = example_groups[0]
 
     # Mock user lookup: one exists, one doesn't
-    mock_existing_user = MagicMock(spec=UserSQLModel)
+    mock_existing_user = mocker.MagicMock(spec=UserSQLModel)
     mock_existing_user.username = "existing_user"
-    mock_existing_user_groups_collection = MagicMock(spec=list)
+    mock_existing_user_groups_collection = mocker.MagicMock(spec=list)
     mock_existing_user.groups = mock_existing_user_groups_collection
-    mock_existing_user._sa_instance_state = MagicMock()
+    mock_existing_user._sa_instance_state = mocker.MagicMock()
     mock_existing_user._sa_instance_state.manager.initialize_collection.return_value = (
-        MagicMock(),
+        mocker.MagicMock(),
         mock_existing_user_groups_collection,
     )
 
@@ -302,13 +302,13 @@ def test_add_users_to_group_with_nonexistent_user(
 
     def query_side_effect(model):
         if model.__name__ == "Group":
-            mock_group_query = MagicMock()
+            mock_group_query = mocker.MagicMock()
             mock_group_query.filter.return_value.first.return_value = mock_group
             return mock_group_query
         elif model.__name__ == "User":
-            mock_user_query = MagicMock()
-            mock_user_query.filter.side_effect = lambda expr: MagicMock(
-                first=MagicMock(
+            mock_user_query = mocker.MagicMock()
+            mock_user_query.filter.side_effect = lambda expr: mocker.MagicMock(
+                first=mocker.MagicMock(
                     return_value=mock_user_query_results.get(expr.right.value)
                 )
             )
@@ -347,10 +347,10 @@ def test_add_users_to_group_not_found(fastapi_test_client, db):
 
 def test_remove_users_from_group(fastapi_test_client, db, example_groups, mocker):
     """Test the remove_users_from_group endpoint."""
-    mock_group = MagicMock(spec=GroupSQLModel)  # Use a fresh mock for the group
+    mock_group = mocker.MagicMock(spec=GroupSQLModel)  # Use a fresh mock for the group
     mock_group.name = "GroupForRemoveTest"
 
-    mock_user_to_remove = MagicMock(spec=UserSQLModel)
+    mock_user_to_remove = mocker.MagicMock(spec=UserSQLModel)
     mock_user_to_remove.id = 101
     mock_user_to_remove.display_name = "User To Remove"
     mock_user_to_remove.username = "user_to_remove_uname"
@@ -361,16 +361,16 @@ def test_remove_users_from_group(fastapi_test_client, db, example_groups, mocker
     mock_user_to_remove.is_admin = False
 
     # Configure _sa_instance_state for mock_user_to_remove.groups (backref)
-    mock_user_to_remove_groups_collection = MagicMock(spec=list)
+    mock_user_to_remove_groups_collection = mocker.MagicMock(spec=list)
     mock_user_to_remove.groups = mock_user_to_remove_groups_collection
-    mock_user_to_remove._sa_instance_state = MagicMock()
+    mock_user_to_remove._sa_instance_state = mocker.MagicMock()
     mock_user_to_remove._sa_instance_state.manager.initialize_collection.return_value = (
-        MagicMock(),
+        mocker.MagicMock(),
         mock_user_to_remove_groups_collection,
     )
 
-    # Configure mock_group.users to be a MagicMock list that "contains" the user to be removed
-    users_collection_on_group = MagicMock(spec=list)
+    # Configure mock_group.users to be a mocker.MagicMock list that "contains" the user to be removed
+    users_collection_on_group = mocker.MagicMock(spec=list)
     users_collection_on_group.__contains__.side_effect = (
         lambda item: item == mock_user_to_remove
     )
@@ -383,13 +383,13 @@ def test_remove_users_from_group(fastapi_test_client, db, example_groups, mocker
 
     def query_side_effect(model):
         if model.__name__ == "Group":
-            mock_group_query = MagicMock()
+            mock_group_query = mocker.MagicMock()
             mock_group_query.filter.return_value.first.return_value = mock_group
             return mock_group_query
         elif model.__name__ == "User":
-            mock_user_query = MagicMock()
-            mock_user_query.filter.side_effect = lambda expr: MagicMock(
-                first=MagicMock(
+            mock_user_query = mocker.MagicMock()
+            mock_user_query.filter.side_effect = lambda expr: mocker.MagicMock(
+                first=mocker.MagicMock(
                     return_value=mock_user_query_results.get(expr.right.value)
                 )
             )
@@ -438,20 +438,20 @@ def test_remove_users_from_group_user_not_in_group(
     """Test removing a user that exists but is not in the specified group."""
     mock_group = example_groups[0]
 
-    users_collection_mock = MagicMock(spec=list)
+    users_collection_mock = mocker.MagicMock(spec=list)
     # Explicitly mock the __contains__ method on the users_collection_mock
-    users_collection_mock.__contains__ = MagicMock(
+    users_collection_mock.__contains__ = mocker.MagicMock(
         return_value=False
     )  # User is NOT in the group
     mock_group.users = users_collection_mock
 
-    mock_user_not_in_group = MagicMock(spec=UserSQLModel)
+    mock_user_not_in_group = mocker.MagicMock(spec=UserSQLModel)
     mock_user_not_in_group.username = "user_not_in_group_uname"
-    mock_user_not_in_group_groups_collection = MagicMock(spec=list)
+    mock_user_not_in_group_groups_collection = mocker.MagicMock(spec=list)
     mock_user_not_in_group.groups = mock_user_not_in_group_groups_collection
-    mock_user_not_in_group._sa_instance_state = MagicMock()
+    mock_user_not_in_group._sa_instance_state = mocker.MagicMock()
     mock_user_not_in_group._sa_instance_state.manager.initialize_collection.return_value = (
-        MagicMock(),
+        mocker.MagicMock(),
         mock_user_not_in_group_groups_collection,
     )
 
@@ -459,16 +459,16 @@ def test_remove_users_from_group_user_not_in_group(
 
     def query_side_effect(model):
         if model.__name__ == "Group":
-            return MagicMock(
-                filter=MagicMock(
-                    return_value=MagicMock(first=MagicMock(return_value=mock_group))
+            return mocker.MagicMock(
+                filter=mocker.MagicMock(
+                    return_value=mocker.MagicMock(first=mocker.MagicMock(return_value=mock_group))
                 )
             )
         elif model.__name__ == "User":
-            return MagicMock(
-                filter=MagicMock(
-                    return_value=MagicMock(
-                        first=MagicMock(return_value=mock_user_not_in_group)
+            return mocker.MagicMock(
+                filter=mocker.MagicMock(
+                    return_value=mocker.MagicMock(
+                        first=mocker.MagicMock(return_value=mock_user_not_in_group)
                     )
                 )
             )

--- a/src/tests/api/v1/metrics_test.py
+++ b/src/tests/api/v1/metrics_test.py
@@ -63,9 +63,7 @@ def test_query_prometheus_range(mocker):
 
 
 def test_get_celery_task_metrics(mocker, monkeypatch):
-    mock_query_prometheus_range = mocker.patch(
-        "api.v1.metrics.query_prometheus_range"
-    )
+    mock_query_prometheus_range = mocker.patch("api.v1.metrics.query_prometheus_range")
     mock_prometheus_response = {
         "status": "success",
         "data": {
@@ -125,9 +123,7 @@ def test_format_prometheus_data():
 
 
 def test_get_celery_task_metrics_no_prometheus(mocker):
-    mock_query_prometheus_range = mocker.patch(
-        "api.v1.metrics.query_prometheus_range"
-    )
+    mock_query_prometheus_range = mocker.patch("api.v1.metrics.query_prometheus_range")
     mock_query_prometheus_range.return_value = []
     request_body = MetricsRequest(
         metric_name="celery_task_completed_total",

--- a/src/tests/api/v1/users_test.py
+++ b/src/tests/api/v1/users_test.py
@@ -26,23 +26,20 @@ def test_get_current_user(fastapi_test_client, user_response):
 
 
 search_user_response = UserSearchResponse(
-        display_name="Test User",
-        username="test_user",
-        profile_picture_url="http://localhost/profile/pic",
-        id=1,
-        created_at = "2025-01-07T18:29:07.772000Z",
-        updated_at = "2025-01-07T18:29:07.772000Z",
-        deleted_at = None,
-        is_deleted = False
-    ).model_dump(mode="json")
+    display_name="Test User",
+    username="test_user",
+    profile_picture_url="http://localhost/profile/pic",
+    id=1,
+    created_at="2025-01-07T18:29:07.772000Z",
+    updated_at="2025-01-07T18:29:07.772000Z",
+    deleted_at=None,
+    is_deleted=False,
+).model_dump(mode="json")
+
 
 @pytest.mark.parametrize(
     "search_string, expected_response",
-    [
-        ("test_user", [search_user_response]),
-        ("", []),
-        ("test", [])
-    ],
+    [("test_user", [search_user_response]), ("", []), ("test", [])],
 )
 def test_search_users_with_query(
     fastapi_test_client, mocker, search_string, expected_response
@@ -50,12 +47,16 @@ def test_search_users_with_query(
     """Test the search_users_with_query endpoint."""
     mock_search_users = mocker.patch("api.v1.users.search_users")
     mock_search_users.return_value = expected_response
-    response = fastapi_test_client.post("/users/search", json={"search_string": search_string})
+    response = fastapi_test_client.post(
+        "/users/search", json={"search_string": search_string}
+    )
     assert response.status_code == 200
     assert response.json() == expected_response
 
 
-def test_get_api_key_for_current_user(fastapi_test_client, mocker, user_api_key_response):
+def test_get_api_key_for_current_user(
+    fastapi_test_client, mocker, user_api_key_response
+):
     """Test the get_api_key_for_current_user endpoint."""
     mock_get_user_api_keys_from_db = mocker.patch(
         "api.v1.users.get_user_api_keys_from_db"
@@ -89,7 +90,9 @@ def test_create_api_key_for_current_user(fastapi_test_client, mocker, regular_us
     )
     mock_create_user_api_key_in_db.return_value = None
     mock_config = mocker.patch("config.get_config")
-    mock_config.return_value = {"auth": {"jwt_header_default_refresh_expire_minutes": 120}}
+    mock_config.return_value = {
+        "auth": {"jwt_header_default_refresh_expire_minutes": 120}
+    }
     request_body = {
         "display_name": "new_api_key",
         "description": "new key description",
@@ -109,4 +112,3 @@ def test_delete_api_key(fastapi_test_client, mocker):
     response = fastapi_test_client.delete("/users/me/apikeys/1")
     assert response.status_code == 200
     mock_delete_user_api_key_from_db.assert_called_once()
-

--- a/src/tests/api/v1/workflows_test.py
+++ b/src/tests/api/v1/workflows_test.py
@@ -15,7 +15,6 @@
 """Tests for workflows endpoints."""
 
 import json
-from unittest.mock import ANY
 
 import pytest
 from celery.canvas import Signature
@@ -197,7 +196,7 @@ async def test_run_workflow(
     mock_get_workflow_from_db = mocker.patch("api.v1.workflows.get_workflow_from_db")
     mock_get_workflow_from_db.return_value = workflow_db_model
     mock_create_workflow = mocker.patch("api.v1.workflows.create_workflow_signature")
-    mock_create_workflow.return_value.apply_async.return_value = ANY
+    mock_create_workflow.return_value.apply_async.return_value = mocker.ANY
     mock_makedirs = mocker.patch("os.makedirs")
     mocker.patch("os.path.exists", return_value=False)  # Path doesn't exist
 
@@ -251,7 +250,7 @@ async def test_run_workflow_nested_tasks(
     mock_get_workflow_from_db = mocker.patch("api.v1.workflows.get_workflow_from_db")
     mock_get_workflow_from_db.return_value = workflow_db_model
     mock_create_workflow = mocker.patch("api.v1.workflows.create_workflow_signature")
-    mock_create_workflow.return_value.apply_async.return_value = ANY
+    mock_create_workflow.return_value.apply_async.return_value = mocker.ANY
     mock_makedirs = mocker.patch("os.makedirs")
     mocker.patch("os.path.exists", return_value=False)  # Path doesn't exist
 
@@ -501,3 +500,122 @@ def test_get_task_signature(mocker, db, user_db_model, task_response, workflow_d
     assert created_task.description is None
     assert created_task.uuid == "test_uuid"
     assert json.loads(created_task.config) == {"param1": "value1"}
+
+
+def test_create_workflow_signature_chain_multiple(
+    mocker, db, regular_user, workflow_schema_mock
+):
+    """Test create_workflow_signature with a chain of multiple tasks."""
+    task_data = {
+        "type": "chain",
+        "tasks": [
+            {
+                "type": "task",
+                "task_name": "task1",
+                "queue_name": "q1",
+                "task_config": [],
+                "tasks": [],
+            },
+            {
+                "type": "task",
+                "task_name": "task2",
+                "queue_name": "q2",
+                "task_config": [],
+                "tasks": [],
+            },
+        ],
+    }
+    input_files = []
+    output_path = ""
+
+    mock_get_task_signature = mocker.patch("api.v1.workflows.get_task_signature")
+    mock_get_task_signature.return_value = mocker.MagicMock(spec=Signature)
+
+    # Mock celery_group to consume the generator
+    mocker.patch("api.v1.workflows.celery_group", side_effect=lambda x: list(x))
+
+    from api.v1.workflows import create_workflow_signature
+
+    sig = create_workflow_signature(
+        db,
+        regular_user,
+        task_data,
+        input_files,
+        output_path,
+        workflow_schema_mock,
+    )
+
+    assert sig is not None
+    assert mock_get_task_signature.call_count == 2
+
+
+
+def test_create_workflow_signature_chord(
+    mocker, db, regular_user, workflow_schema_mock
+):
+    """Test create_workflow_signature with a chord."""
+    task_data = {
+        "type": "chord",
+        "tasks": [
+            {
+                "type": "task",
+                "task_name": "task1",
+                "queue_name": "q1",
+                "task_config": [],
+                "tasks": [],
+            }
+        ],
+        "callback": {
+            "type": "task",
+            "task_name": "callback_task",
+            "queue_name": "q2",
+            "task_config": [],
+            "tasks": [],
+        },
+    }
+    input_files = []
+    output_path = ""
+
+    mock_get_task_signature = mocker.patch("api.v1.workflows.get_task_signature")
+    mock_get_task_signature.return_value = mocker.MagicMock(spec=Signature)
+
+    from api.v1.workflows import create_workflow_signature
+
+    sig = create_workflow_signature(
+        db,
+        regular_user,
+        task_data,
+        input_files,
+        output_path,
+        workflow_schema_mock,
+    )
+
+    assert sig is not None
+    assert mock_get_task_signature.call_count == 2
+
+
+def test_get_workflow_status_running(fastapi_test_client, mocker):
+    """Test get_workflow_status returns RUNNING."""
+    mock_workflow = mocker.MagicMock()
+    mock_task = mocker.MagicMock()
+    mock_task.status_short = "STARTED"
+    mock_task.display_name = "Mock Task"
+    mock_task.description = "Mock Description"
+    mock_task.uuid = "3fa85f64-5717-4562-b3fc-2c963f66afa7"
+    
+    mock_user = mocker.MagicMock()
+    mock_user.display_name = "Mock User"
+    mock_user.username = "mockuser"
+    mock_user.profile_picture_url = "http://localhost/profile/pic"
+    mock_user.uuid = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    
+    mock_task.user = mock_user
+    mock_workflow.tasks = [mock_task]
+
+    mocker.patch("api.v1.workflows.get_workflow_from_db", return_value=mock_workflow)
+
+    response = fastapi_test_client.get("/folders/1/workflows/1/status")
+    assert response.status_code == 200
+    assert response.json()["status"] == "RUNNING"
+
+

--- a/src/tests/api/v1/workflows_test.py
+++ b/src/tests/api/v1/workflows_test.py
@@ -39,7 +39,9 @@ async def test_create_workflow(
         "api.v1.workflows.get_workflow_template_from_db"
     )
     mock_get_workflow_template_from_db.return_value = workflow_schema_mock
-    mock_create_subfolder_in_db = mocker.patch("api.v1.workflows.create_subfolder_in_db")
+    mock_create_subfolder_in_db = mocker.patch(
+        "api.v1.workflows.create_subfolder_in_db"
+    )
     mock_create_subfolder_in_db.return_value = folder_db_model
 
     mock_create_workflow_in_db = mocker.patch("api.v1.workflows.create_workflow_in_db")
@@ -59,7 +61,9 @@ async def test_create_workflow_no_template(
 ):
     """Test create workflow route with no template."""
 
-    mock_create_subfolder_in_db = mocker.patch("api.v1.workflows.create_subfolder_in_db")
+    mock_create_subfolder_in_db = mocker.patch(
+        "api.v1.workflows.create_subfolder_in_db"
+    )
     mock_create_subfolder_in_db.return_value = folder_db_model
     mock_create_workflow_in_db = mocker.patch("api.v1.workflows.create_workflow_in_db")
     mock_create_workflow_in_db.return_value = workflow_response
@@ -77,7 +81,11 @@ async def test_create_workflow_no_template(
 
 @pytest.mark.asyncio
 async def test_create_workflow_no_template_no_files(
-    fastapi_async_test_client, mocker, folder_db_model, workflow_response, workflow_schema_mock
+    fastapi_async_test_client,
+    mocker,
+    folder_db_model,
+    workflow_response,
+    workflow_schema_mock,
 ):
     """Test create workflow route with no template and no files."""
     folder_id = 1
@@ -85,7 +93,9 @@ async def test_create_workflow_no_template_no_files(
         "api.v1.workflows.get_workflow_template_from_db"
     )
     mock_get_workflow_template_from_db.return_value = workflow_schema_mock
-    mock_create_subfolder_in_db = mocker.patch("api.v1.workflows.create_subfolder_in_db")
+    mock_create_subfolder_in_db = mocker.patch(
+        "api.v1.workflows.create_subfolder_in_db"
+    )
     mock_create_subfolder_in_db.return_value = folder_db_model
 
     mock_create_workflow_in_db = mocker.patch("api.v1.workflows.create_workflow_in_db")
@@ -155,7 +165,9 @@ async def test_copy_workflow(
     mock_get_workflow_from_db = mocker.patch("api.v1.workflows.get_workflow_from_db")
     mock_get_workflow_from_db.return_value = workflow_db_model
 
-    mock_create_subfolder_in_db = mocker.patch("api.v1.workflows.create_subfolder_in_db")
+    mock_create_subfolder_in_db = mocker.patch(
+        "api.v1.workflows.create_subfolder_in_db"
+    )
     mock_create_subfolder_in_db.return_value = workflow_db_model.folder
 
     mock_create_workflow_in_db = mocker.patch("api.v1.workflows.create_workflow_in_db")
@@ -171,11 +183,15 @@ async def test_copy_workflow(
 
 
 def test_delete_workflow(fastapi_test_client, mocker, db):
-    mock_delete_workflow_from_db = mocker.patch("api.v1.workflows.delete_workflow_from_db")
+    mock_delete_workflow_from_db = mocker.patch(
+        "api.v1.workflows.delete_workflow_from_db"
+    )
     folder_id = 1
     workflow_id = 1
 
-    response = fastapi_test_client.delete(f"/folders/{folder_id}/workflows/{workflow_id}")
+    response = fastapi_test_client.delete(
+        f"/folders/{folder_id}/workflows/{workflow_id}"
+    )
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     mock_delete_workflow_from_db.assert_called_once_with(db, workflow_id)
@@ -192,7 +208,10 @@ async def test_run_workflow(
     setup_file_path_mock,
 ):
     """Test run workflow route."""
-    mocker.patch("datastores.sql.models.folder.get_config", return_value={"server": {"storage_path": "/tmp/test"}})
+    mocker.patch(
+        "datastores.sql.models.folder.get_config",
+        return_value={"server": {"storage_path": "/tmp/test"}},
+    )
     mock_get_workflow_from_db = mocker.patch("api.v1.workflows.get_workflow_from_db")
     mock_get_workflow_from_db.return_value = workflow_db_model
     mock_create_workflow = mocker.patch("api.v1.workflows.create_workflow_signature")
@@ -246,7 +265,10 @@ async def test_run_workflow_nested_tasks(
     setup_file_path_mock,
 ):
     """Test run workflow route with group tasks."""
-    mocker.patch("datastores.sql.models.folder.get_config", return_value={"server": {"storage_path": "/tmp/test"}})
+    mocker.patch(
+        "datastores.sql.models.folder.get_config",
+        return_value={"server": {"storage_path": "/tmp/test"}},
+    )
     mock_get_workflow_from_db = mocker.patch("api.v1.workflows.get_workflow_from_db")
     mock_get_workflow_from_db.return_value = workflow_db_model
     mock_create_workflow = mocker.patch("api.v1.workflows.create_workflow_signature")
@@ -324,7 +346,9 @@ async def test_get_workflow_template_by_id(
     mock_get_workflow_template_by_id.return_value = workflow_template_response
 
     workflow_template_id = 1
-    response = await fastapi_async_test_client.get(f"/workflows/templates/{workflow_template_id}")
+    response = await fastapi_async_test_client.get(
+        f"/workflows/templates/{workflow_template_id}"
+    )
     assert response.status_code == 200
     assert response.json() == workflow_template_response.model_dump(mode="json")
 
@@ -345,7 +369,9 @@ async def test_create_workflow_template(
     mock_create_workflow_template_in_db.return_value = workflow_template_response
 
     request = {"display_name": "test template", "workflow_id": 1}
-    response = await fastapi_async_test_client.post("/workflows/templates/", json=request)
+    response = await fastapi_async_test_client.post(
+        "/workflows/templates/", json=request
+    )
     assert response.status_code == 200
 
     # Verify that the spec_json is stringified before being passed to the database function
@@ -412,7 +438,9 @@ async def test_update_workflow_template(
 
 
 @pytest.mark.asyncio
-async def test_create_workflow_template_invalid_workflow(fastapi_async_test_client, mocker, db):
+async def test_create_workflow_template_invalid_workflow(
+    fastapi_async_test_client, mocker, db
+):
     """Test create workflow template route with invalid workflow ID."""
 
     mock_get_workflow_from_db = mocker.patch("api.v1.workflows.get_workflow_from_db")
@@ -420,7 +448,9 @@ async def test_create_workflow_template_invalid_workflow(fastapi_async_test_clie
 
     request = {"display_name": "test template", "workflow_id": 1}
 
-    response = await fastapi_async_test_client.post("/workflows/templates/", json=request)
+    response = await fastapi_async_test_client.post(
+        "/workflows/templates/", json=request
+    )
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -473,7 +503,9 @@ def test_replace_uuids_replace_with(mocker):
     assert data["uuid"] == replace_value
 
 
-def test_get_task_signature(mocker, db, user_db_model, task_response, workflow_db_model):
+def test_get_task_signature(
+    mocker, db, user_db_model, task_response, workflow_db_model
+):
     """Test get_task_signature function."""
 
     mock_create_task_in_db = mocker.patch("api.v1.workflows.create_task_in_db")
@@ -549,7 +581,6 @@ def test_create_workflow_signature_chain_multiple(
     assert mock_get_task_signature.call_count == 2
 
 
-
 def test_create_workflow_signature_chord(
     mocker, db, regular_user, workflow_schema_mock
 ):
@@ -602,13 +633,13 @@ def test_get_workflow_status_running(fastapi_test_client, mocker):
     mock_task.display_name = "Mock Task"
     mock_task.description = "Mock Description"
     mock_task.uuid = "3fa85f64-5717-4562-b3fc-2c963f66afa7"
-    
+
     mock_user = mocker.MagicMock()
     mock_user.display_name = "Mock User"
     mock_user.username = "mockuser"
     mock_user.profile_picture_url = "http://localhost/profile/pic"
     mock_user.uuid = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-    
+
     mock_task.user = mock_user
     mock_workflow.tasks = [mock_task]
 
@@ -617,5 +648,3 @@ def test_get_workflow_status_running(fastapi_test_client, mocker):
     response = fastapi_test_client.get("/folders/1/workflows/1/status")
     assert response.status_code == 200
     assert response.json()["status"] == "RUNNING"
-
-


### PR DESCRIPTION
### Summary
This PR introduces comprehensive unit tests for the API v1 modules, replacing previous `unittest.mock` usage with `pytest` fixtures and the `mocker` fixture for better isolation and maintainability.

### Changes
- **Files API (`files_test.py`)**: Added tests for content retrieval (including encoding fallbacks and unescaped content), file downloads, listing workflows for a file, generating and retrieving file summaries via LLM, fetching task status, downloading task results, and managing file-specific chat history.
- **Folders API (`folders_test.py`)**: Added tests for CRUD operations on folders, adding/removing files to/from folders, and managing folder sharing.
- **Groups API (`groups_test.py`)**: Added tests for listing groups, creating/deleting groups, and managing group memberships.
- **Workflows API (`workflows_test.py`)**: Added tests for creating and executing workflows, listing workflow templates, and checking workflow status.
- **Fixtures (`conftest.py`)**: Added shared fixtures for database session mocking and test client setup.