### PR TITLE
Add unit tests for auth modules

### DIFF
--- a/src/tests/auth/common_test.py
+++ b/src/tests/auth/common_test.py
@@ -21,11 +21,13 @@ from auth.common import (
     validate_jwt_token,
 )
 
+
 def test_generate_csrf_token():
     """Test generate_csrf_token."""
     token = generate_csrf_token()
     assert isinstance(token, str)
     assert len(token) > 0
+
 
 def test_create_and_validate_jwt_token():
     """Test create_jwt_token and validate_jwt_token."""
@@ -33,7 +35,7 @@ def test_create_and_validate_jwt_token():
     expire_minutes = 10
     subject = "test-user"
     token_type = "access"
-    
+
     # Create token
     token = create_jwt_token(
         audience=audience,
@@ -42,17 +44,18 @@ def test_create_and_validate_jwt_token():
         token_type=token_type,
     )
     assert isinstance(token, str)
-    
+
     # Validate token
     payload = validate_jwt_token(
         token=token,
         expected_token_type=token_type,
         expected_audience=audience,
     )
-    
+
     assert payload["sub"] == subject
     assert payload["aud"] == audience
     assert payload["token_type"] == token_type
+
 
 def test_validate_jwt_token_wrong_type():
     """Test validate_jwt_token with wrong token type."""
@@ -63,8 +66,9 @@ def test_validate_jwt_token_wrong_type():
         subject="test-user",
         token_type="access",
     )
-    
+
     from fastapi import HTTPException
+
     with pytest.raises(HTTPException) as exc_info:
         validate_jwt_token(
             token=token,

--- a/src/tests/auth/common_test.py
+++ b/src/tests/auth/common_test.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for auth common functions."""
+
+import pytest
+from auth.common import (
+    generate_csrf_token,
+    create_jwt_token,
+    validate_jwt_token,
+)
+
+def test_generate_csrf_token():
+    """Test generate_csrf_token."""
+    token = generate_csrf_token()
+    assert isinstance(token, str)
+    assert len(token) > 0
+
+def test_create_and_validate_jwt_token():
+    """Test create_jwt_token and validate_jwt_token."""
+    audience = "test-audience"
+    expire_minutes = 10
+    subject = "test-user"
+    token_type = "access"
+    
+    # Create token
+    token = create_jwt_token(
+        audience=audience,
+        expire_minutes=expire_minutes,
+        subject=subject,
+        token_type=token_type,
+    )
+    assert isinstance(token, str)
+    
+    # Validate token
+    payload = validate_jwt_token(
+        token=token,
+        expected_token_type=token_type,
+        expected_audience=audience,
+    )
+    
+    assert payload["sub"] == subject
+    assert payload["aud"] == audience
+    assert payload["token_type"] == token_type
+
+def test_validate_jwt_token_wrong_type():
+    """Test validate_jwt_token with wrong token type."""
+    audience = "test-audience"
+    token = create_jwt_token(
+        audience=audience,
+        expire_minutes=10,
+        subject="test-user",
+        token_type="access",
+    )
+    
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        validate_jwt_token(
+            token=token,
+            expected_token_type="refresh",
+            expected_audience=audience,
+        )
+    assert "Wrong token type" in str(exc_info.value.detail)

--- a/src/tests/auth/google_test.py
+++ b/src/tests/auth/google_test.py
@@ -1,0 +1,279 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastapi import HTTPException
+from google.auth import exceptions as google_exceptions
+from starlette.responses import RedirectResponse
+from authlib.integrations.starlette_client import OAuthError
+
+# Mock config before importing google
+try:
+    from config import config
+    config["auth"] = {
+        "google": {
+            "client_id": "test_id",
+            "client_secret": "test_secret",
+            "allowlist": [],
+            "public_access": False,
+            "workspace_domain": False,
+            "allowed_robot_accounts": [],
+            "extra_audiences": []
+        },
+        "jwt_cookie_refresh_expire_minutes": 60,
+        "jwt_cookie_access_expire_minutes": 15
+    }
+except:
+    pass
+
+import auth.google as google_auth
+
+def test_validate_user_info_robot():
+    """Test allowed robot accounts bypass checks."""
+    google_auth.GOOGLE_ALLOWED_ROBOT_ACCOUNTS = ["robot@example.com"]
+    user_info = {"email": "robot@example.com"}
+    # Should not raise any exception
+    google_auth._validate_user_info(user_info)
+
+def test_validate_user_info_workspace_ok():
+    """Test valid workspace domain."""
+    google_auth.GOOGLE_WORKSPACE_DOMAIN = "example.com"
+    google_auth.GOOGLE_PUBLIC_ACCESS = True
+    google_auth.GOOGLE_ALLOWED_ROBOT_ACCOUNTS = []
+    user_info = {"email": "user@example.com", "hd": "example.com"}
+    # Should not raise any exception
+    google_auth._validate_user_info(user_info)
+
+def test_validate_user_info_workspace_fail():
+    """Test invalid workspace domain."""
+    google_auth.GOOGLE_WORKSPACE_DOMAIN = "example.com"
+    google_auth.GOOGLE_ALLOWED_ROBOT_ACCOUNTS = []
+    user_info = {"email": "user@gmail.com", "hd": "gmail.com"}
+    with pytest.raises(HTTPException) as excinfo:
+        google_auth._validate_user_info(user_info)
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "Unauthorized. Invalid workspace domain."
+
+def test_validate_user_info_public_access():
+    """Test public access allowed."""
+    google_auth.GOOGLE_WORKSPACE_DOMAIN = False
+    google_auth.GOOGLE_PUBLIC_ACCESS = True
+    google_auth.GOOGLE_ALLOWED_ROBOT_ACCOUNTS = []
+    user_info = {"email": "user@any.com"}
+    # Should not raise any exception
+    google_auth._validate_user_info(user_info)
+
+def test_validate_user_info_allowlist_ok():
+    """Test user in allowlist."""
+    google_auth.GOOGLE_WORKSPACE_DOMAIN = False
+    google_auth.GOOGLE_PUBLIC_ACCESS = False
+    google_auth.GOOGLE_ALLOW_LIST = ["user@allowed.com"]
+    google_auth.GOOGLE_ALLOWED_ROBOT_ACCOUNTS = []
+    user_info = {"email": "user@allowed.com"}
+    # Should not raise any exception
+    google_auth._validate_user_info(user_info)
+
+def test_validate_user_info_allowlist_fail():
+    """Test user not in allowlist."""
+    google_auth.GOOGLE_WORKSPACE_DOMAIN = False
+    google_auth.GOOGLE_PUBLIC_ACCESS = False
+    google_auth.GOOGLE_ALLOW_LIST = ["user@allowed.com"]
+    google_auth.GOOGLE_ALLOWED_ROBOT_ACCOUNTS = []
+    user_info = {"email": "user@notallowed.com"}
+    with pytest.raises(HTTPException) as excinfo:
+        google_auth._validate_user_info(user_info)
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "Unauthorized. Not in allowlist."
+
+@pytest.mark.asyncio
+async def test_auth_header_token_missing_header(mocker):
+    """Test auth_header_token with missing header."""
+    with pytest.raises(HTTPException) as excinfo:
+        await google_auth.auth_header_token(x_goog_id_token=None, db=mocker.MagicMock())
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "Unauthorized, missing x-google-id-token header."
+
+@pytest.mark.asyncio
+async def test_auth_header_token_valid_new_user(mocker):
+    """Test auth_header_token with valid token and new user."""
+    mock_validate_google_token = mocker.patch("auth.google._validate_google_token")
+    mock_get_user = mocker.patch("auth.google.get_user_by_email_from_db")
+    mock_validate_user_info = mocker.patch("auth.google._validate_user_info")
+    mock_create_jwt = mocker.patch("auth.google.create_jwt_token")
+    
+    mock_validate_google_token.return_value = {
+        "email": "new@example.com",
+        "name": "New User",
+        "picture": "http://pic"
+    }
+    mock_get_user.return_value = None
+    mock_create_jwt.return_value = "mocked_jwt"
+    
+    mock_db = mocker.MagicMock()
+    
+    response = await google_auth.auth_header_token(x_goog_id_token="valid_token", db=mock_db)
+    
+    assert response["x-openrelik-refresh-token"] == "mocked_jwt"
+    assert response["x-openrelik-access-token"] == "mocked_jwt"
+    mock_validate_user_info.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_auth_header_token_valid_existing_user(mocker):
+    """Test auth_header_token with valid token and existing user."""
+    mock_validate_google_token = mocker.patch("auth.google._validate_google_token")
+    mock_get_user = mocker.patch("auth.google.get_user_by_email_from_db")
+    mock_validate_user_info = mocker.patch("auth.google._validate_user_info")
+    mock_create_jwt = mocker.patch("auth.google.create_jwt_token")
+    
+    mock_validate_google_token.return_value = {
+        "email": "existing@example.com",
+        "name": "Existing User",
+        "picture": "http://pic"
+    }
+    mock_user = mocker.MagicMock()
+    mock_user.uuid.hex = "existing_uuid"
+    mock_get_user.return_value = mock_user
+    mock_create_jwt.return_value = "mocked_jwt"
+    
+    mock_db = mocker.MagicMock()
+    
+    response = await google_auth.auth_header_token(x_goog_id_token="valid_token", db=mock_db)
+    
+    assert response["x-openrelik-refresh-token"] == "mocked_jwt"
+    assert response["x-openrelik-access-token"] == "mocked_jwt"
+    mock_validate_user_info.assert_called_once()
+
+def test_validate_google_token_success(mocker):
+    """Test _validate_google_token success."""
+    mock_verify = mocker.patch("auth.google.id_token.verify_oauth2_token")
+    mock_verify.return_value = {"aud": "test_aud", "email": "user@example.com"}
+    result = google_auth._validate_google_token("valid_token", ["test_aud"])
+    assert result["email"] == "user@example.com"
+
+def test_validate_google_token_aud_mismatch(mocker):
+    """Test _validate_google_token audience mismatch."""
+    mock_verify = mocker.patch("auth.google.id_token.verify_oauth2_token")
+    mock_verify.return_value = {"aud": "wrong_aud"}
+    with pytest.raises(HTTPException) as excinfo:
+        google_auth._validate_google_token("valid_token", ["test_aud"])
+    assert excinfo.value.status_code == 401
+    assert "Could not verify audience" in excinfo.value.detail
+
+def test_validate_google_token_value_error(mocker):
+    """Test _validate_google_token value error."""
+    mock_verify = mocker.patch("auth.google.id_token.verify_oauth2_token")
+    mock_verify.side_effect = ValueError("Invalid token")
+    with pytest.raises(HTTPException) as excinfo:
+        google_auth._validate_google_token("invalid_token", ["test_aud"])
+    assert excinfo.value.status_code == 401
+    assert "Invalid token" in excinfo.value.detail
+
+def test_validate_google_token_auth_error(mocker):
+    """Test _validate_google_token auth error."""
+    mock_verify = mocker.patch("auth.google.id_token.verify_oauth2_token")
+    mock_verify.side_effect = google_exceptions.GoogleAuthError("Auth error")
+    with pytest.raises(HTTPException) as excinfo:
+        google_auth._validate_google_token("invalid_token", ["test_aud"])
+    assert excinfo.value.status_code == 401
+    assert "Could not verify token" in excinfo.value.detail
+
+@pytest.mark.asyncio
+async def test_login(mocker):
+    """Test login endpoint redirects to Google."""
+    mock_authorize_redirect = mocker.patch("auth.google.oauth.google.authorize_redirect")
+    mock_request = mocker.MagicMock()
+    mock_request.url_for.return_value = "http://test/auth"
+    mock_authorize_redirect.return_value = "mock_redirect"
+    
+    google_auth.GOOGLE_WORKSPACE_DOMAIN = "example.com"
+    
+    response = await google_auth.login(mock_request)
+    
+    assert response == "mock_redirect"
+    mock_authorize_redirect.assert_called_once_with(mock_request, "http://test/auth", hd="example.com")
+
+@pytest.mark.asyncio
+async def test_auth_callback(mocker):
+    """Test auth callback success."""
+    mock_authorize_access_token = mocker.patch("auth.google.oauth.google.authorize_access_token")
+    mock_get_user = mocker.patch("auth.google.get_user_by_email_from_db")
+    mock_validate_user_info = mocker.patch("auth.google._validate_user_info")
+    mock_create_jwt = mocker.patch("auth.google.create_jwt_token")
+    mock_generate_csrf = mocker.patch("auth.google.generate_csrf_token")
+    
+    mock_authorize_access_token.return_value = {
+        "userinfo": {
+            "email": "user@example.com",
+            "name": "User",
+            "picture": "http://pic"
+        }
+    }
+    mock_user = mocker.MagicMock()
+    mock_user.uuid.hex = "user_uuid"
+    mock_get_user.return_value = mock_user
+    mock_create_jwt.return_value = "mocked_jwt"
+    mock_generate_csrf.return_value = "mocked_csrf"
+    
+    mock_request = mocker.MagicMock()
+    mock_db = mocker.MagicMock()
+    
+    response = await google_auth.auth(mock_request, db=mock_db)
+    
+    assert isinstance(response, RedirectResponse)
+    assert response.status_code == 307
+
+@pytest.mark.asyncio
+async def test_auth_callback_oauth_error(mocker):
+    """Test auth callback with OAuth error."""
+    mock_authorize_access_token = mocker.patch("auth.google.oauth.google.authorize_access_token")
+    mock_authorize_access_token.side_effect = OAuthError(error="invalid_grant")
+    
+    mock_request = mocker.MagicMock()
+    mock_db = mocker.MagicMock()
+    
+    response = await google_auth.auth(mock_request, db=mock_db)
+    
+    assert response == {"OAuth error": "invalid_grant"}
+
+@pytest.mark.asyncio
+async def test_auth_callback_new_user(mocker):
+    """Test auth callback with new user."""
+    mock_authorize_access_token = mocker.patch("auth.google.oauth.google.authorize_access_token")
+    mock_get_user = mocker.patch("auth.google.get_user_by_email_from_db")
+    mock_validate_user_info = mocker.patch("auth.google._validate_user_info")
+    mock_create_user = mocker.patch("auth.google.create_user_in_db")
+    mock_create_jwt = mocker.patch("auth.google.create_jwt_token")
+    mock_generate_csrf = mocker.patch("auth.google.generate_csrf_token")
+    
+    mock_authorize_access_token.return_value = {
+        "userinfo": {
+            "email": "new@example.com",
+            "name": "New User",
+            "picture": "http://pic"
+        }
+    }
+    mock_get_user.return_value = None
+    mock_user = mocker.MagicMock()
+    mock_user.uuid.hex = "new_uuid"
+    mock_create_user.return_value = mock_user
+    mock_create_jwt.return_value = "mocked_jwt"
+    mock_generate_csrf.return_value = "mocked_csrf"
+    
+    mock_request = mocker.MagicMock()
+    mock_db = mocker.MagicMock()
+    
+    response = await google_auth.auth(mock_request, db=mock_db)
+    
+    assert isinstance(response, RedirectResponse)
+    mock_create_user.assert_called_once()

--- a/src/tests/auth/google_test.py
+++ b/src/tests/auth/google_test.py
@@ -21,6 +21,7 @@ from authlib.integrations.starlette_client import OAuthError
 # Mock config before importing google
 try:
     from config import config
+
     config["auth"] = {
         "google": {
             "client_id": "test_id",
@@ -29,15 +30,16 @@ try:
             "public_access": False,
             "workspace_domain": False,
             "allowed_robot_accounts": [],
-            "extra_audiences": []
+            "extra_audiences": [],
         },
         "jwt_cookie_refresh_expire_minutes": 60,
-        "jwt_cookie_access_expire_minutes": 15
+        "jwt_cookie_access_expire_minutes": 15,
     }
 except:
     pass
 
 import auth.google as google_auth
+
 
 def test_validate_user_info_robot():
     """Test allowed robot accounts bypass checks."""
@@ -45,6 +47,7 @@ def test_validate_user_info_robot():
     user_info = {"email": "robot@example.com"}
     # Should not raise any exception
     google_auth._validate_user_info(user_info)
+
 
 def test_validate_user_info_workspace_ok():
     """Test valid workspace domain."""
@@ -54,6 +57,7 @@ def test_validate_user_info_workspace_ok():
     user_info = {"email": "user@example.com", "hd": "example.com"}
     # Should not raise any exception
     google_auth._validate_user_info(user_info)
+
 
 def test_validate_user_info_workspace_fail():
     """Test invalid workspace domain."""
@@ -65,6 +69,7 @@ def test_validate_user_info_workspace_fail():
     assert excinfo.value.status_code == 401
     assert excinfo.value.detail == "Unauthorized. Invalid workspace domain."
 
+
 def test_validate_user_info_public_access():
     """Test public access allowed."""
     google_auth.GOOGLE_WORKSPACE_DOMAIN = False
@@ -73,6 +78,7 @@ def test_validate_user_info_public_access():
     user_info = {"email": "user@any.com"}
     # Should not raise any exception
     google_auth._validate_user_info(user_info)
+
 
 def test_validate_user_info_allowlist_ok():
     """Test user in allowlist."""
@@ -83,6 +89,7 @@ def test_validate_user_info_allowlist_ok():
     user_info = {"email": "user@allowed.com"}
     # Should not raise any exception
     google_auth._validate_user_info(user_info)
+
 
 def test_validate_user_info_allowlist_fail():
     """Test user not in allowlist."""
@@ -96,6 +103,7 @@ def test_validate_user_info_allowlist_fail():
     assert excinfo.value.status_code == 401
     assert excinfo.value.detail == "Unauthorized. Not in allowlist."
 
+
 @pytest.mark.asyncio
 async def test_auth_header_token_missing_header(mocker):
     """Test auth_header_token with missing header."""
@@ -104,6 +112,7 @@ async def test_auth_header_token_missing_header(mocker):
     assert excinfo.value.status_code == 401
     assert excinfo.value.detail == "Unauthorized, missing x-google-id-token header."
 
+
 @pytest.mark.asyncio
 async def test_auth_header_token_valid_new_user(mocker):
     """Test auth_header_token with valid token and new user."""
@@ -111,22 +120,25 @@ async def test_auth_header_token_valid_new_user(mocker):
     mock_get_user = mocker.patch("auth.google.get_user_by_email_from_db")
     mock_validate_user_info = mocker.patch("auth.google._validate_user_info")
     mock_create_jwt = mocker.patch("auth.google.create_jwt_token")
-    
+
     mock_validate_google_token.return_value = {
         "email": "new@example.com",
         "name": "New User",
-        "picture": "http://pic"
+        "picture": "http://pic",
     }
     mock_get_user.return_value = None
     mock_create_jwt.return_value = "mocked_jwt"
-    
+
     mock_db = mocker.MagicMock()
-    
-    response = await google_auth.auth_header_token(x_goog_id_token="valid_token", db=mock_db)
-    
+
+    response = await google_auth.auth_header_token(
+        x_goog_id_token="valid_token", db=mock_db
+    )
+
     assert response["x-openrelik-refresh-token"] == "mocked_jwt"
     assert response["x-openrelik-access-token"] == "mocked_jwt"
     mock_validate_user_info.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_auth_header_token_valid_existing_user(mocker):
@@ -135,24 +147,27 @@ async def test_auth_header_token_valid_existing_user(mocker):
     mock_get_user = mocker.patch("auth.google.get_user_by_email_from_db")
     mock_validate_user_info = mocker.patch("auth.google._validate_user_info")
     mock_create_jwt = mocker.patch("auth.google.create_jwt_token")
-    
+
     mock_validate_google_token.return_value = {
         "email": "existing@example.com",
         "name": "Existing User",
-        "picture": "http://pic"
+        "picture": "http://pic",
     }
     mock_user = mocker.MagicMock()
     mock_user.uuid.hex = "existing_uuid"
     mock_get_user.return_value = mock_user
     mock_create_jwt.return_value = "mocked_jwt"
-    
+
     mock_db = mocker.MagicMock()
-    
-    response = await google_auth.auth_header_token(x_goog_id_token="valid_token", db=mock_db)
-    
+
+    response = await google_auth.auth_header_token(
+        x_goog_id_token="valid_token", db=mock_db
+    )
+
     assert response["x-openrelik-refresh-token"] == "mocked_jwt"
     assert response["x-openrelik-access-token"] == "mocked_jwt"
     mock_validate_user_info.assert_called_once()
+
 
 def test_validate_google_token_success(mocker):
     """Test _validate_google_token success."""
@@ -160,6 +175,7 @@ def test_validate_google_token_success(mocker):
     mock_verify.return_value = {"aud": "test_aud", "email": "user@example.com"}
     result = google_auth._validate_google_token("valid_token", ["test_aud"])
     assert result["email"] == "user@example.com"
+
 
 def test_validate_google_token_aud_mismatch(mocker):
     """Test _validate_google_token audience mismatch."""
@@ -170,6 +186,7 @@ def test_validate_google_token_aud_mismatch(mocker):
     assert excinfo.value.status_code == 401
     assert "Could not verify audience" in excinfo.value.detail
 
+
 def test_validate_google_token_value_error(mocker):
     """Test _validate_google_token value error."""
     mock_verify = mocker.patch("auth.google.id_token.verify_oauth2_token")
@@ -178,6 +195,7 @@ def test_validate_google_token_value_error(mocker):
         google_auth._validate_google_token("invalid_token", ["test_aud"])
     assert excinfo.value.status_code == 401
     assert "Invalid token" in excinfo.value.detail
+
 
 def test_validate_google_token_auth_error(mocker):
     """Test _validate_google_token auth error."""
@@ -188,35 +206,43 @@ def test_validate_google_token_auth_error(mocker):
     assert excinfo.value.status_code == 401
     assert "Could not verify token" in excinfo.value.detail
 
+
 @pytest.mark.asyncio
 async def test_login(mocker):
     """Test login endpoint redirects to Google."""
-    mock_authorize_redirect = mocker.patch("auth.google.oauth.google.authorize_redirect")
+    mock_authorize_redirect = mocker.patch(
+        "auth.google.oauth.google.authorize_redirect"
+    )
     mock_request = mocker.MagicMock()
     mock_request.url_for.return_value = "http://test/auth"
     mock_authorize_redirect.return_value = "mock_redirect"
-    
+
     google_auth.GOOGLE_WORKSPACE_DOMAIN = "example.com"
-    
+
     response = await google_auth.login(mock_request)
-    
+
     assert response == "mock_redirect"
-    mock_authorize_redirect.assert_called_once_with(mock_request, "http://test/auth", hd="example.com")
+    mock_authorize_redirect.assert_called_once_with(
+        mock_request, "http://test/auth", hd="example.com"
+    )
+
 
 @pytest.mark.asyncio
 async def test_auth_callback(mocker):
     """Test auth callback success."""
-    mock_authorize_access_token = mocker.patch("auth.google.oauth.google.authorize_access_token")
+    mock_authorize_access_token = mocker.patch(
+        "auth.google.oauth.google.authorize_access_token"
+    )
     mock_get_user = mocker.patch("auth.google.get_user_by_email_from_db")
     mock_validate_user_info = mocker.patch("auth.google._validate_user_info")
     mock_create_jwt = mocker.patch("auth.google.create_jwt_token")
     mock_generate_csrf = mocker.patch("auth.google.generate_csrf_token")
-    
+
     mock_authorize_access_token.return_value = {
         "userinfo": {
             "email": "user@example.com",
             "name": "User",
-            "picture": "http://pic"
+            "picture": "http://pic",
         }
     }
     mock_user = mocker.MagicMock()
@@ -224,43 +250,49 @@ async def test_auth_callback(mocker):
     mock_get_user.return_value = mock_user
     mock_create_jwt.return_value = "mocked_jwt"
     mock_generate_csrf.return_value = "mocked_csrf"
-    
+
     mock_request = mocker.MagicMock()
     mock_db = mocker.MagicMock()
-    
+
     response = await google_auth.auth(mock_request, db=mock_db)
-    
+
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 307
+
 
 @pytest.mark.asyncio
 async def test_auth_callback_oauth_error(mocker):
     """Test auth callback with OAuth error."""
-    mock_authorize_access_token = mocker.patch("auth.google.oauth.google.authorize_access_token")
+    mock_authorize_access_token = mocker.patch(
+        "auth.google.oauth.google.authorize_access_token"
+    )
     mock_authorize_access_token.side_effect = OAuthError(error="invalid_grant")
-    
+
     mock_request = mocker.MagicMock()
     mock_db = mocker.MagicMock()
-    
+
     response = await google_auth.auth(mock_request, db=mock_db)
-    
+
     assert response == {"OAuth error": "invalid_grant"}
+
 
 @pytest.mark.asyncio
 async def test_auth_callback_new_user(mocker):
     """Test auth callback with new user."""
-    mock_authorize_access_token = mocker.patch("auth.google.oauth.google.authorize_access_token")
+    mock_authorize_access_token = mocker.patch(
+        "auth.google.oauth.google.authorize_access_token"
+    )
     mock_get_user = mocker.patch("auth.google.get_user_by_email_from_db")
     mock_validate_user_info = mocker.patch("auth.google._validate_user_info")
     mock_create_user = mocker.patch("auth.google.create_user_in_db")
     mock_create_jwt = mocker.patch("auth.google.create_jwt_token")
     mock_generate_csrf = mocker.patch("auth.google.generate_csrf_token")
-    
+
     mock_authorize_access_token.return_value = {
         "userinfo": {
             "email": "new@example.com",
             "name": "New User",
-            "picture": "http://pic"
+            "picture": "http://pic",
         }
     }
     mock_get_user.return_value = None
@@ -269,11 +301,11 @@ async def test_auth_callback_new_user(mocker):
     mock_create_user.return_value = mock_user
     mock_create_jwt.return_value = "mocked_jwt"
     mock_generate_csrf.return_value = "mocked_csrf"
-    
+
     mock_request = mocker.MagicMock()
     mock_db = mocker.MagicMock()
-    
+
     response = await google_auth.auth(mock_request, db=mock_db)
-    
+
     assert isinstance(response, RedirectResponse)
     mock_create_user.assert_called_once()

--- a/src/tests/auth/local_test.py
+++ b/src/tests/auth/local_test.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for local auth endpoint."""
+
+import pytest
+from fastapi import HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from auth.local import auth_local
+
+@pytest.mark.asyncio
+async def test_auth_local_success(mocker, db):
+    """Test auth_local success."""
+    # Setup mocks
+    mock_generate_csrf = mocker.patch("auth.local.generate_csrf_token")
+    mock_create_jwt = mocker.patch("auth.local.create_jwt_token")
+    mock_hasher = mocker.patch("auth.local.password_hasher")
+    mock_get_user = mocker.patch("auth.local.get_user_by_username_from_db")
+
+    mock_user = mocker.MagicMock()
+    mock_user.password_hash = "correct_hash"
+    mock_user.uuid.hex = "mock_uuid"
+    mock_get_user.return_value = mock_user
+    
+    mock_hasher.verify.return_value = True
+    mock_create_jwt.return_value = "mock_token"
+    mock_generate_csrf.return_value = "mock_csrf"
+    
+    # Mock form data
+    form_data = OAuth2PasswordRequestForm(username="testuser", password="password")
+    
+    # Mock request
+    request = mocker.MagicMock()
+    
+    # Call function
+    response = await auth_local(request, form_data, db)
+    
+    # Assertions
+    mock_get_user.assert_called_once_with(db, username="testuser")
+    mock_hasher.verify.assert_called_once_with("correct_hash", "password")
+    assert response.status_code == 200
+    
+@pytest.mark.asyncio
+async def test_auth_local_wrong_password(mocker, db):
+    """Test auth_local with wrong password."""
+    import argon2
+    # Setup mocks
+    mock_hasher = mocker.patch("auth.local.password_hasher")
+    mock_get_user = mocker.patch("auth.local.get_user_by_username_from_db")
+
+    mock_user = mocker.MagicMock()
+    mock_user.password_hash = "correct_hash"
+    mock_get_user.return_value = mock_user
+    
+    mock_hasher.verify.side_effect = argon2.exceptions.VerifyMismatchError
+    
+    # Mock form data
+    form_data = OAuth2PasswordRequestForm(username="testuser", password="wrong_password")
+    
+    # Mock request
+    request = mocker.MagicMock()
+    
+    # Call function and assert exception
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_local(request, form_data, db)
+    
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "Incorrect username or password" in exc_info.value.detail
+
+@pytest.mark.asyncio
+async def test_auth_local_user_not_found(mocker, db):
+    """Test auth_local with user not found."""
+    # Setup mocks
+    mock_get_user = mocker.patch("auth.local.get_user_by_username_from_db")
+    mock_get_user.return_value = None
+    
+    # Mock form data
+    form_data = OAuth2PasswordRequestForm(username="nonexistent", password="password")
+    
+    # Mock request
+    request = mocker.MagicMock()
+    
+    # Call function and assert exception
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_local(request, form_data, db)
+    
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "Incorrect username or password" in exc_info.value.detail

--- a/src/tests/auth/local_test.py
+++ b/src/tests/auth/local_test.py
@@ -19,6 +19,7 @@ from fastapi import HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from auth.local import auth_local
 
+
 @pytest.mark.asyncio
 async def test_auth_local_success(mocker, db):
     """Test auth_local success."""
@@ -32,29 +33,31 @@ async def test_auth_local_success(mocker, db):
     mock_user.password_hash = "correct_hash"
     mock_user.uuid.hex = "mock_uuid"
     mock_get_user.return_value = mock_user
-    
+
     mock_hasher.verify.return_value = True
     mock_create_jwt.return_value = "mock_token"
     mock_generate_csrf.return_value = "mock_csrf"
-    
+
     # Mock form data
     form_data = OAuth2PasswordRequestForm(username="testuser", password="password")
-    
+
     # Mock request
     request = mocker.MagicMock()
-    
+
     # Call function
     response = await auth_local(request, form_data, db)
-    
+
     # Assertions
     mock_get_user.assert_called_once_with(db, username="testuser")
     mock_hasher.verify.assert_called_once_with("correct_hash", "password")
     assert response.status_code == 200
-    
+
+
 @pytest.mark.asyncio
 async def test_auth_local_wrong_password(mocker, db):
     """Test auth_local with wrong password."""
     import argon2
+
     # Setup mocks
     mock_hasher = mocker.patch("auth.local.password_hasher")
     mock_get_user = mocker.patch("auth.local.get_user_by_username_from_db")
@@ -62,21 +65,24 @@ async def test_auth_local_wrong_password(mocker, db):
     mock_user = mocker.MagicMock()
     mock_user.password_hash = "correct_hash"
     mock_get_user.return_value = mock_user
-    
+
     mock_hasher.verify.side_effect = argon2.exceptions.VerifyMismatchError
-    
+
     # Mock form data
-    form_data = OAuth2PasswordRequestForm(username="testuser", password="wrong_password")
-    
+    form_data = OAuth2PasswordRequestForm(
+        username="testuser", password="wrong_password"
+    )
+
     # Mock request
     request = mocker.MagicMock()
-    
+
     # Call function and assert exception
     with pytest.raises(HTTPException) as exc_info:
         await auth_local(request, form_data, db)
-    
+
     assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert "Incorrect username or password" in exc_info.value.detail
+
 
 @pytest.mark.asyncio
 async def test_auth_local_user_not_found(mocker, db):
@@ -84,16 +90,16 @@ async def test_auth_local_user_not_found(mocker, db):
     # Setup mocks
     mock_get_user = mocker.patch("auth.local.get_user_by_username_from_db")
     mock_get_user.return_value = None
-    
+
     # Mock form data
     form_data = OAuth2PasswordRequestForm(username="nonexistent", password="password")
-    
+
     # Mock request
     request = mocker.MagicMock()
-    
+
     # Call function and assert exception
     with pytest.raises(HTTPException) as exc_info:
         await auth_local(request, form_data, db)
-    
+
     assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert "Incorrect username or password" in exc_info.value.detail


### PR DESCRIPTION
### Summary
This PR adds unit tests for the authentication modules, ensuring correct behavior of local and Google OAuth flows.

### Changes
- **Google OAuth (`google_test.py`)**: Tests for the Google authentication flow, including mocking external token verification and handling user creation on first login.
- **Local Auth (`local_test.py`)**: Tests for local username/password login, password hashing verification, and token generation.
- **Common Auth (`common_test.py`)**: Tests for shared authentication utilities and decorators.
