### PR TITLE
Add unit tests for datastore modules

### DIFF
--- a/src/tests/datastores/file_test.py
+++ b/src/tests/datastores/file_test.py
@@ -32,8 +32,15 @@ from datastores.sql.crud.file import (
     create_file_chat_message_in_db,
     get_latest_file_chat_from_db,
 )
-from datastores.sql.models.file import File, FileSummary, FileReport, FileChat, FileChatMessage
+from datastores.sql.models.file import (
+    File,
+    FileSummary,
+    FileReport,
+    FileChat,
+    FileChatMessage,
+)
 from datastores.sql.models.user import UserRole
+
 
 def test_get_files_from_db(db):
     """Test get_files_from_db."""
@@ -50,6 +57,7 @@ def test_get_files_from_db(db):
     assert len(result) == 1
     assert result[0].id == 1
 
+
 def test_get_file_from_db(db):
     """Test get_file_from_db."""
     file_id = 1
@@ -59,6 +67,7 @@ def test_get_file_from_db(db):
 
     db.get.assert_called_once_with(File, file_id)
     assert result.id == file_id
+
 
 def test_get_file_by_uuid_from_db(db):
     """Test get_file_by_uuid_from_db."""
@@ -73,6 +82,7 @@ def test_get_file_by_uuid_from_db(db):
     mock_query.filter_by.assert_called_once_with(uuid=uuid.UUID(uuid_str))
     assert result.uuid == uuid.UUID(uuid_str)
 
+
 def test_delete_file_from_db(mocker, db):
     """Test delete_file_from_db."""
     file_id = 1
@@ -85,6 +95,7 @@ def test_delete_file_from_db(mocker, db):
     mock_file.soft_delete.assert_called_once()
     db.commit.assert_called_once()
 
+
 def test_create_file_in_db(mocker, db):
     """Test create_file_in_db."""
     mock_get_folder = mocker.patch("datastores.sql.crud.file.get_folder_from_db")
@@ -96,139 +107,148 @@ def test_create_file_in_db(mocker, db):
     mock_folder = mocker.MagicMock()
     mock_folder.path = "dummy_folder_path"
     mock_get_folder.return_value = mock_folder
-    
+
     mock_magic.side_effect = ["plain text", "text/plain"]
     mock_stat.return_value.st_size = 100
-    
+
     mock_file_create = mocker.MagicMock()
     mock_file_create.folder_id = 1
     mock_file_create.uuid = uuid.uuid4()
     mock_file_create.extension = "txt"
     mock_file_create.data_type = None
     mock_file_create.model_dump.return_value = {"folder_id": 1}
-    
+
     mock_current_user = mocker.MagicMock()
-    
+
     mock_file_instance = mocker.MagicMock()
     mock_file_cls.return_value = mock_file_instance
-    
+
     mock_user_role_instance = mocker.MagicMock()
     mock_user_role.return_value = mock_user_role_instance
-    
+
     result = create_file_in_db(db, mock_file_create, mock_current_user)
-    
+
     mock_file_cls.assert_called_once()
     db.add.assert_any_call(mock_file_instance)
     db.add.assert_any_call(mock_user_role_instance)
     assert result == mock_file_instance
 
+
 def test_get_file_summary_from_db(db):
     """Test get_file_summary_from_db."""
     summary_id = 1
     db.get.return_value = FileSummary(id=summary_id)
-    
+
     result = get_file_summary_from_db(db, summary_id)
-    
+
     db.get.assert_called_once_with(FileSummary, summary_id)
     assert result.id == summary_id
+
 
 def test_create_file_summary_in_db(mocker, db):
     """Test create_file_summary_in_db."""
     mock_file_summary_cls = mocker.patch("datastores.sql.crud.file.FileSummary")
-    
+
     mock_summary_create = mocker.MagicMock()
     mock_summary_create.model_dump.return_value = {"summary": "test"}
-    
+
     mock_summary_instance = mocker.MagicMock()
     mock_file_summary_cls.return_value = mock_summary_instance
-    
+
     result = create_file_summary_in_db(db, mock_summary_create)
-    
+
     mock_file_summary_cls.assert_called_once_with(summary="test")
     db.add.assert_called_once_with(mock_summary_instance)
     db.commit.assert_called_once()
     assert result == mock_summary_instance
 
+
 def test_update_file_summary_in_db(mocker, db):
     """Test update_file_summary_in_db."""
     mock_summary = mocker.MagicMock()
-    
+
     result = update_file_summary_in_db(db, mock_summary)
-    
+
     db.add.assert_called_once_with(mock_summary)
     db.commit.assert_called_once()
     assert result == mock_summary
+
 
 def test_create_file_report_in_db(mocker, db):
     """Test create_file_report_in_db."""
     mock_get_file = mocker.patch("datastores.sql.crud.file.get_file_by_uuid_from_db")
     mock_file_report_cls = mocker.patch("datastores.sql.crud.file.FileReport")
-    
+
     mock_report_create = mocker.MagicMock()
     mock_report_create.input_file_uuid = "uuid1"
     mock_report_create.content_file_uuid = "uuid2"
     mock_report_create.summary = "summary"
     mock_report_create.priority = "high"
-    
+
     mock_input_file = mocker.MagicMock()
     mock_content_file = mocker.MagicMock()
     mock_content_file.path = "dummy_path"
-    
+
     mock_get_file.side_effect = [mock_input_file, mock_content_file]
-    
+
     mock_report_instance = mocker.MagicMock()
     mock_file_report_cls.return_value = mock_report_instance
-    
+
     m = mocker.mock_open(read_data="report content")
     mocker.patch("builtins.open", m)
-    
+
     result = create_file_report_in_db(db, mock_report_create, 1)
-        
+
     mock_file_report_cls.assert_called_once_with(
         summary="summary",
         priority="high",
         markdown="report content",
         file=mock_input_file,
         content_file=mock_content_file,
-        task_id=1
+        task_id=1,
     )
     db.add.assert_called_once_with(mock_report_instance)
     db.commit.assert_called_once()
     assert result == mock_report_instance
 
+
 def test_create_file_chat_in_db(mocker, db):
     """Test create_file_chat_in_db."""
     mock_file_chat_cls = mocker.patch("datastores.sql.crud.file.FileChat")
-    
+
     mock_chat_create = mocker.MagicMock()
     mock_chat_create.model_dump.return_value = {"file_id": 1}
-    
+
     mock_chat_instance = mocker.MagicMock()
     mock_file_chat_cls.return_value = mock_chat_instance
-    
+
     result = create_file_chat_in_db(db, mock_chat_create)
-    
+
     mock_file_chat_cls.assert_called_once_with(file_id=1)
     db.add.assert_called_once_with(mock_chat_instance)
     db.commit.assert_called_once()
     assert result == mock_chat_instance
 
+
 def test_create_file_chat_message_in_db(mocker, db):
     """Test create_file_chat_message_in_db."""
-    mock_file_chat_message_cls = mocker.patch("datastores.sql.crud.file.FileChatMessage")
-    
+    mock_file_chat_message_cls = mocker.patch(
+        "datastores.sql.crud.file.FileChatMessage"
+    )
+
     mock_msg_create = mocker.MagicMock()
     mock_msg_create.model_dump.return_value = {"chat_id": 1}
-    
+
     mock_msg_instance = mocker.MagicMock()
     mock_file_chat_message_cls.return_value = mock_msg_instance
-    
+
     result = create_file_chat_message_in_db(db, mock_msg_create)
-    
+
     mock_file_chat_message_cls.assert_called_once_with(chat_id=1)
     db.add.assert_called_once_with(mock_msg_instance)
     db.commit.assert_called_once()
     assert result == mock_msg_instance
+
 
 def test_get_latest_file_chat_from_db(db):
     """Test get_latest_file_chat_from_db."""
@@ -236,9 +256,9 @@ def test_get_latest_file_chat_from_db(db):
     mock_filter = mock_query.filter_by.return_value
     mock_order = mock_filter.order_by.return_value
     mock_order.first.return_value = FileChat(id=1)
-    
+
     result = get_latest_file_chat_from_db(db, 1, 1)
-    
+
     db.query.assert_called_once_with(FileChat)
     mock_query.filter_by.assert_called_once_with(file_id=1, user_id=1)
     assert result.id == 1

--- a/src/tests/datastores/file_test.py
+++ b/src/tests/datastores/file_test.py
@@ -1,0 +1,244 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for file CRUD operations."""
+
+import os
+import uuid
+import pytest
+
+from datastores.sql.crud.file import (
+    get_files_from_db,
+    get_file_from_db,
+    get_file_by_uuid_from_db,
+    create_file_in_db,
+    delete_file_from_db,
+    get_file_summary_from_db,
+    create_file_summary_in_db,
+    update_file_summary_in_db,
+    create_file_report_in_db,
+    create_file_chat_in_db,
+    create_file_chat_message_in_db,
+    get_latest_file_chat_from_db,
+)
+from datastores.sql.models.file import File, FileSummary, FileReport, FileChat, FileChatMessage
+from datastores.sql.models.user import UserRole
+
+def test_get_files_from_db(db):
+    """Test get_files_from_db."""
+    folder_id = 1
+    mock_query = db.query.return_value
+    mock_filter = mock_query.filter_by.return_value
+    mock_order = mock_filter.order_by.return_value
+    mock_order.all.return_value = [File(id=1, folder_id=folder_id)]
+
+    result = get_files_from_db(db, folder_id)
+
+    db.query.assert_called_once_with(File)
+    mock_query.filter_by.assert_called_once_with(folder_id=folder_id)
+    assert len(result) == 1
+    assert result[0].id == 1
+
+def test_get_file_from_db(db):
+    """Test get_file_from_db."""
+    file_id = 1
+    db.get.return_value = File(id=file_id)
+
+    result = get_file_from_db(db, file_id)
+
+    db.get.assert_called_once_with(File, file_id)
+    assert result.id == file_id
+
+def test_get_file_by_uuid_from_db(db):
+    """Test get_file_by_uuid_from_db."""
+    uuid_str = str(uuid.uuid4())
+    mock_query = db.query.return_value
+    mock_filter = mock_query.filter_by.return_value
+    mock_filter.first.return_value = File(id=1, uuid=uuid.UUID(uuid_str))
+
+    result = get_file_by_uuid_from_db(db, uuid_str)
+
+    db.query.assert_called_once_with(File)
+    mock_query.filter_by.assert_called_once_with(uuid=uuid.UUID(uuid_str))
+    assert result.uuid == uuid.UUID(uuid_str)
+
+def test_delete_file_from_db(mocker, db):
+    """Test delete_file_from_db."""
+    file_id = 1
+    mock_file = mocker.MagicMock()
+    db.get.return_value = mock_file
+
+    delete_file_from_db(db, file_id)
+
+    db.get.assert_called_once_with(File, file_id)
+    mock_file.soft_delete.assert_called_once()
+    db.commit.assert_called_once()
+
+def test_create_file_in_db(mocker, db):
+    """Test create_file_in_db."""
+    mock_get_folder = mocker.patch("datastores.sql.crud.file.get_folder_from_db")
+    mock_magic = mocker.patch("datastores.sql.crud.file.magic.from_file")
+    mock_stat = mocker.patch("datastores.sql.crud.file.os.stat")
+    mock_file_cls = mocker.patch("datastores.sql.crud.file.File")
+    mock_user_role = mocker.patch("datastores.sql.crud.file.UserRole")
+
+    mock_folder = mocker.MagicMock()
+    mock_folder.path = "dummy_folder_path"
+    mock_get_folder.return_value = mock_folder
+    
+    mock_magic.side_effect = ["plain text", "text/plain"]
+    mock_stat.return_value.st_size = 100
+    
+    mock_file_create = mocker.MagicMock()
+    mock_file_create.folder_id = 1
+    mock_file_create.uuid = uuid.uuid4()
+    mock_file_create.extension = "txt"
+    mock_file_create.data_type = None
+    mock_file_create.model_dump.return_value = {"folder_id": 1}
+    
+    mock_current_user = mocker.MagicMock()
+    
+    mock_file_instance = mocker.MagicMock()
+    mock_file_cls.return_value = mock_file_instance
+    
+    mock_user_role_instance = mocker.MagicMock()
+    mock_user_role.return_value = mock_user_role_instance
+    
+    result = create_file_in_db(db, mock_file_create, mock_current_user)
+    
+    mock_file_cls.assert_called_once()
+    db.add.assert_any_call(mock_file_instance)
+    db.add.assert_any_call(mock_user_role_instance)
+    assert result == mock_file_instance
+
+def test_get_file_summary_from_db(db):
+    """Test get_file_summary_from_db."""
+    summary_id = 1
+    db.get.return_value = FileSummary(id=summary_id)
+    
+    result = get_file_summary_from_db(db, summary_id)
+    
+    db.get.assert_called_once_with(FileSummary, summary_id)
+    assert result.id == summary_id
+
+def test_create_file_summary_in_db(mocker, db):
+    """Test create_file_summary_in_db."""
+    mock_file_summary_cls = mocker.patch("datastores.sql.crud.file.FileSummary")
+    
+    mock_summary_create = mocker.MagicMock()
+    mock_summary_create.model_dump.return_value = {"summary": "test"}
+    
+    mock_summary_instance = mocker.MagicMock()
+    mock_file_summary_cls.return_value = mock_summary_instance
+    
+    result = create_file_summary_in_db(db, mock_summary_create)
+    
+    mock_file_summary_cls.assert_called_once_with(summary="test")
+    db.add.assert_called_once_with(mock_summary_instance)
+    db.commit.assert_called_once()
+    assert result == mock_summary_instance
+
+def test_update_file_summary_in_db(mocker, db):
+    """Test update_file_summary_in_db."""
+    mock_summary = mocker.MagicMock()
+    
+    result = update_file_summary_in_db(db, mock_summary)
+    
+    db.add.assert_called_once_with(mock_summary)
+    db.commit.assert_called_once()
+    assert result == mock_summary
+
+def test_create_file_report_in_db(mocker, db):
+    """Test create_file_report_in_db."""
+    mock_get_file = mocker.patch("datastores.sql.crud.file.get_file_by_uuid_from_db")
+    mock_file_report_cls = mocker.patch("datastores.sql.crud.file.FileReport")
+    
+    mock_report_create = mocker.MagicMock()
+    mock_report_create.input_file_uuid = "uuid1"
+    mock_report_create.content_file_uuid = "uuid2"
+    mock_report_create.summary = "summary"
+    mock_report_create.priority = "high"
+    
+    mock_input_file = mocker.MagicMock()
+    mock_content_file = mocker.MagicMock()
+    mock_content_file.path = "dummy_path"
+    
+    mock_get_file.side_effect = [mock_input_file, mock_content_file]
+    
+    mock_report_instance = mocker.MagicMock()
+    mock_file_report_cls.return_value = mock_report_instance
+    
+    m = mocker.mock_open(read_data="report content")
+    mocker.patch("builtins.open", m)
+    
+    result = create_file_report_in_db(db, mock_report_create, 1)
+        
+    mock_file_report_cls.assert_called_once_with(
+        summary="summary",
+        priority="high",
+        markdown="report content",
+        file=mock_input_file,
+        content_file=mock_content_file,
+        task_id=1
+    )
+    db.add.assert_called_once_with(mock_report_instance)
+    db.commit.assert_called_once()
+    assert result == mock_report_instance
+
+def test_create_file_chat_in_db(mocker, db):
+    """Test create_file_chat_in_db."""
+    mock_file_chat_cls = mocker.patch("datastores.sql.crud.file.FileChat")
+    
+    mock_chat_create = mocker.MagicMock()
+    mock_chat_create.model_dump.return_value = {"file_id": 1}
+    
+    mock_chat_instance = mocker.MagicMock()
+    mock_file_chat_cls.return_value = mock_chat_instance
+    
+    result = create_file_chat_in_db(db, mock_chat_create)
+    
+    mock_file_chat_cls.assert_called_once_with(file_id=1)
+    db.add.assert_called_once_with(mock_chat_instance)
+    db.commit.assert_called_once()
+    assert result == mock_chat_instance
+
+def test_create_file_chat_message_in_db(mocker, db):
+    """Test create_file_chat_message_in_db."""
+    mock_file_chat_message_cls = mocker.patch("datastores.sql.crud.file.FileChatMessage")
+    
+    mock_msg_create = mocker.MagicMock()
+    mock_msg_create.model_dump.return_value = {"chat_id": 1}
+    
+    mock_msg_instance = mocker.MagicMock()
+    mock_file_chat_message_cls.return_value = mock_msg_instance
+    
+    result = create_file_chat_message_in_db(db, mock_msg_create)
+    
+    mock_file_chat_message_cls.assert_called_once_with(chat_id=1)
+    db.add.assert_called_once_with(mock_msg_instance)
+    db.commit.assert_called_once()
+    assert result == mock_msg_instance
+
+def test_get_latest_file_chat_from_db(db):
+    """Test get_latest_file_chat_from_db."""
+    mock_query = db.query.return_value
+    mock_filter = mock_query.filter_by.return_value
+    mock_order = mock_filter.order_by.return_value
+    mock_order.first.return_value = FileChat(id=1)
+    
+    result = get_latest_file_chat_from_db(db, 1, 1)
+    
+    db.query.assert_called_once_with(FileChat)
+    mock_query.filter_by.assert_called_once_with(file_id=1, user_id=1)
+    assert result.id == 1

--- a/src/tests/datastores/folder_test.py
+++ b/src/tests/datastores/folder_test.py
@@ -31,6 +31,7 @@ from datastores.sql.models.folder import Folder
 from datastores.sql.models.user import User
 from api.v1 import schemas
 
+
 def test_get_root_folders_from_db(db):
     """Test get_root_folders_from_db."""
     current_user = User(id=1)
@@ -45,6 +46,7 @@ def test_get_root_folders_from_db(db):
     db.query.assert_called_once_with(Folder)
     assert len(result) == 1
     assert result[0].id == 1
+
 
 def test_get_subfolders_from_db(db):
     """Test get_subfolders_from_db."""
@@ -61,6 +63,7 @@ def test_get_subfolders_from_db(db):
     assert len(result) == 1
     assert result[0].id == 2
 
+
 def test_get_folder_from_db(db):
     """Test get_folder_from_db."""
     folder_id = 1
@@ -71,15 +74,18 @@ def test_get_folder_from_db(db):
     db.get.assert_called_once_with(Folder, folder_id)
     assert result.id == folder_id
 
+
 def test_create_root_folder_in_db(mocker, db):
     """Test create_root_folder_in_db."""
     mock_config = mocker.patch("datastores.sql.crud.folder.config")
     mock_os = mocker.patch("datastores.sql.crud.folder.os")
-    
+
     current_user = User(id=1)
     new_folder = schemas.FolderCreateRequest(display_name="New Folder")
-    
-    mock_config.get.return_value.get.return_value.get.return_value = {"default": "default_provider"}
+
+    mock_config.get.return_value.get.return_value.get.return_value = {
+        "default": "default_provider"
+    }
     mock_os.path.exists.return_value = False
 
     result = create_root_folder_in_db(db, new_folder, current_user)
@@ -90,10 +96,11 @@ def test_create_root_folder_in_db(mocker, db):
     mock_os.mkdir.assert_called_once()
     assert result.display_name == "New Folder"
 
+
 def test_get_shared_folders_from_db(mocker, db):
     """Test get_shared_folders_from_db."""
     current_user = User(id=1)
-    
+
     mock_q = mocker.MagicMock()
     db.query.return_value = mock_q
     mock_q.join.return_value = mock_q
@@ -102,18 +109,19 @@ def test_get_shared_folders_from_db(mocker, db):
     mock_q.select_from.return_value = mock_q
     mock_q.outerjoin.return_value = mock_q
     mock_q.order_by.return_value = mock_q
-    
+
     mock_q.all.return_value = [Folder(id=2)]
-    
+
     result = get_shared_folders_from_db(db, current_user)
-    
+
     assert len(result) == 1
     assert result[0].id == 2
+
 
 def test_get_all_folders_from_db_default(mocker, db):
     """Test get_all_folders_from_db in default mode (no search)."""
     current_user = User(id=1)
-    
+
     mock_q = mocker.MagicMock()
     db.query.return_value = mock_q
     mock_q.join.return_value = mock_q
@@ -125,34 +133,35 @@ def test_get_all_folders_from_db_default(mocker, db):
     mock_q.distinct.return_value = mock_q
     mock_q.offset.return_value = mock_q
     mock_q.limit.return_value = mock_q
-    
+
     mock_q.all.return_value = [Folder(id=1), Folder(id=2)]
     mock_q.count.return_value = 2
-    
+
     folders, total = get_all_folders_from_db(db, current_user)
-    
+
     assert len(folders) == 2
     assert total == 2
+
 
 def test_get_all_folders_from_db_search(mocker, db):
     """Test get_all_folders_from_db in search mode."""
     mock_aliased = mocker.patch("datastores.sql.crud.folder.aliased")
     mock_select = mocker.patch("datastores.sql.crud.folder.select")
     mock_union = mocker.patch("datastores.sql.crud.folder.union")
-    
+
     current_user = User(id=1)
-    
+
     # Mock the complex select/union CTE generation
     mock_stmt = mocker.MagicMock()
     mock_select.return_value = mock_stmt
     mock_stmt.join.return_value = mock_stmt
     mock_stmt.filter.return_value = mock_stmt
     mock_stmt.cte.return_value = mocker.MagicMock()
-    
+
     # Mock aliased to return a mock that has .c.id
     mock_cte_alias = mocker.MagicMock()
     mock_aliased.return_value = mock_cte_alias
-    
+
     # Use the fluent mock trick
     mock_q = mocker.MagicMock()
     db.query.return_value = mock_q
@@ -165,60 +174,67 @@ def test_get_all_folders_from_db_search(mocker, db):
     mock_q.distinct.return_value = mock_q
     mock_q.offset.return_value = mock_q
     mock_q.limit.return_value = mock_q
-    
+
     mock_q.all.return_value = [Folder(id=1)]
     mock_q.count.return_value = 1
-    mock_q.scalar.return_value = 1 # For total count in search mode
-    
+    mock_q.scalar.return_value = 1  # For total count in search mode
+
     folders, total = get_all_folders_from_db(db, current_user, search_term="test")
-    
+
     assert len(folders) == 1
     assert total == 1
+
 
 def test_create_subfolder_in_db(mocker, db):
     """Test create_subfolder_in_db."""
     mock_config = mocker.patch("datastores.sql.crud.folder.config")
     mock_get_folder = mocker.patch("datastores.sql.crud.folder.get_folder_from_db")
     mock_os = mocker.patch("datastores.sql.crud.folder.os")
-    
+
     current_user = User(id=1)
     parent_folder = Folder(id=1, uuid=uuid.uuid4())
     mock_get_folder.return_value = parent_folder
-    
+
     new_folder = schemas.FolderCreateRequest(display_name="Subfolder")
-    
-    mock_config.get.return_value.get.return_value.get.return_value = {"default": "default_provider"}
+
+    mock_config.get.return_value.get.return_value.get.return_value = {
+        "default": "default_provider"
+    }
     mock_os.path.exists.return_value = False
-    
-    result = create_subfolder_in_db(db, folder_id=1, new_folder=new_folder, current_user=current_user)
-    
+
+    result = create_subfolder_in_db(
+        db, folder_id=1, new_folder=new_folder, current_user=current_user
+    )
+
     db.add.assert_called()
     db.commit.assert_called()
     mock_os.mkdir.assert_called_once()
     assert result.display_name == "Subfolder"
 
+
 def test_delete_folder_from_db(db):
     """Test delete_folder_from_db."""
     folder_id = 1
-    
+
     mock_execute = db.execute.return_value
     mock_scalars = mock_execute.scalars.return_value
-    mock_scalars.all.return_value = [1, 2, 3] # Folder IDs
-    
+    mock_scalars.all.return_value = [1, 2, 3]  # Folder IDs
+
     delete_folder_from_db(db, folder_id)
-    
+
     assert db.execute.call_count == 3
     db.commit.assert_called_once()
+
 
 def test_delete_folder_from_db_empty(db):
     """Test delete_folder_from_db when no folders found."""
     folder_id = 1
-    
+
     mock_execute = db.execute.return_value
     mock_scalars = mock_execute.scalars.return_value
     mock_scalars.all.return_value = []
-    
+
     delete_folder_from_db(db, folder_id)
-    
+
     assert db.execute.call_count == 1
     db.commit.assert_not_called()

--- a/src/tests/datastores/folder_test.py
+++ b/src/tests/datastores/folder_test.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for folder CRUD operations."""
+
+import uuid
+import pytest
+
+from datastores.sql.crud.folder import (
+    get_root_folders_from_db,
+    get_subfolders_from_db,
+    get_folder_from_db,
+    create_root_folder_in_db,
+    get_shared_folders_from_db,
+    get_all_folders_from_db,
+    create_subfolder_in_db,
+    delete_folder_from_db,
+)
+from datastores.sql.models.folder import Folder
+from datastores.sql.models.user import User
+from api.v1 import schemas
+
+def test_get_root_folders_from_db(db):
+    """Test get_root_folders_from_db."""
+    current_user = User(id=1)
+    mock_query = db.query.return_value
+    mock_join = mock_query.join.return_value
+    mock_filter = mock_join.filter.return_value
+    mock_order = mock_filter.order_by.return_value
+    mock_order.all.return_value = [Folder(id=1, parent_id=None)]
+
+    result = get_root_folders_from_db(db, current_user)
+
+    db.query.assert_called_once_with(Folder)
+    assert len(result) == 1
+    assert result[0].id == 1
+
+def test_get_subfolders_from_db(db):
+    """Test get_subfolders_from_db."""
+    parent_id = 1
+    mock_query = db.query.return_value
+    mock_filter = mock_query.filter_by.return_value
+    mock_order = mock_filter.order_by.return_value
+    mock_order.all.return_value = [Folder(id=2, parent_id=parent_id)]
+
+    result = get_subfolders_from_db(db, parent_id)
+
+    db.query.assert_called_once_with(Folder)
+    mock_query.filter_by.assert_called_once_with(parent_id=parent_id)
+    assert len(result) == 1
+    assert result[0].id == 2
+
+def test_get_folder_from_db(db):
+    """Test get_folder_from_db."""
+    folder_id = 1
+    db.get.return_value = Folder(id=folder_id)
+
+    result = get_folder_from_db(db, folder_id)
+
+    db.get.assert_called_once_with(Folder, folder_id)
+    assert result.id == folder_id
+
+def test_create_root_folder_in_db(mocker, db):
+    """Test create_root_folder_in_db."""
+    mock_config = mocker.patch("datastores.sql.crud.folder.config")
+    mock_os = mocker.patch("datastores.sql.crud.folder.os")
+    
+    current_user = User(id=1)
+    new_folder = schemas.FolderCreateRequest(display_name="New Folder")
+    
+    mock_config.get.return_value.get.return_value.get.return_value = {"default": "default_provider"}
+    mock_os.path.exists.return_value = False
+
+    result = create_root_folder_in_db(db, new_folder, current_user)
+
+    db.add.assert_called()
+    db.commit.assert_called()
+    db.refresh.assert_called()
+    mock_os.mkdir.assert_called_once()
+    assert result.display_name == "New Folder"
+
+def test_get_shared_folders_from_db(mocker, db):
+    """Test get_shared_folders_from_db."""
+    current_user = User(id=1)
+    
+    mock_q = mocker.MagicMock()
+    db.query.return_value = mock_q
+    mock_q.join.return_value = mock_q
+    mock_q.filter.return_value = mock_q
+    mock_q.union.return_value = mock_q
+    mock_q.select_from.return_value = mock_q
+    mock_q.outerjoin.return_value = mock_q
+    mock_q.order_by.return_value = mock_q
+    
+    mock_q.all.return_value = [Folder(id=2)]
+    
+    result = get_shared_folders_from_db(db, current_user)
+    
+    assert len(result) == 1
+    assert result[0].id == 2
+
+def test_get_all_folders_from_db_default(mocker, db):
+    """Test get_all_folders_from_db in default mode (no search)."""
+    current_user = User(id=1)
+    
+    mock_q = mocker.MagicMock()
+    db.query.return_value = mock_q
+    mock_q.join.return_value = mock_q
+    mock_q.filter.return_value = mock_q
+    mock_q.union.return_value = mock_q
+    mock_q.select_from.return_value = mock_q
+    mock_q.outerjoin.return_value = mock_q
+    mock_q.order_by.return_value = mock_q
+    mock_q.distinct.return_value = mock_q
+    mock_q.offset.return_value = mock_q
+    mock_q.limit.return_value = mock_q
+    
+    mock_q.all.return_value = [Folder(id=1), Folder(id=2)]
+    mock_q.count.return_value = 2
+    
+    folders, total = get_all_folders_from_db(db, current_user)
+    
+    assert len(folders) == 2
+    assert total == 2
+
+def test_get_all_folders_from_db_search(mocker, db):
+    """Test get_all_folders_from_db in search mode."""
+    mock_aliased = mocker.patch("datastores.sql.crud.folder.aliased")
+    mock_select = mocker.patch("datastores.sql.crud.folder.select")
+    mock_union = mocker.patch("datastores.sql.crud.folder.union")
+    
+    current_user = User(id=1)
+    
+    # Mock the complex select/union CTE generation
+    mock_stmt = mocker.MagicMock()
+    mock_select.return_value = mock_stmt
+    mock_stmt.join.return_value = mock_stmt
+    mock_stmt.filter.return_value = mock_stmt
+    mock_stmt.cte.return_value = mocker.MagicMock()
+    
+    # Mock aliased to return a mock that has .c.id
+    mock_cte_alias = mocker.MagicMock()
+    mock_aliased.return_value = mock_cte_alias
+    
+    # Use the fluent mock trick
+    mock_q = mocker.MagicMock()
+    db.query.return_value = mock_q
+    mock_q.join.return_value = mock_q
+    mock_q.filter.return_value = mock_q
+    mock_q.union.return_value = mock_q
+    mock_q.select_from.return_value = mock_q
+    mock_q.outerjoin.return_value = mock_q
+    mock_q.order_by.return_value = mock_q
+    mock_q.distinct.return_value = mock_q
+    mock_q.offset.return_value = mock_q
+    mock_q.limit.return_value = mock_q
+    
+    mock_q.all.return_value = [Folder(id=1)]
+    mock_q.count.return_value = 1
+    mock_q.scalar.return_value = 1 # For total count in search mode
+    
+    folders, total = get_all_folders_from_db(db, current_user, search_term="test")
+    
+    assert len(folders) == 1
+    assert total == 1
+
+def test_create_subfolder_in_db(mocker, db):
+    """Test create_subfolder_in_db."""
+    mock_config = mocker.patch("datastores.sql.crud.folder.config")
+    mock_get_folder = mocker.patch("datastores.sql.crud.folder.get_folder_from_db")
+    mock_os = mocker.patch("datastores.sql.crud.folder.os")
+    
+    current_user = User(id=1)
+    parent_folder = Folder(id=1, uuid=uuid.uuid4())
+    mock_get_folder.return_value = parent_folder
+    
+    new_folder = schemas.FolderCreateRequest(display_name="Subfolder")
+    
+    mock_config.get.return_value.get.return_value.get.return_value = {"default": "default_provider"}
+    mock_os.path.exists.return_value = False
+    
+    result = create_subfolder_in_db(db, folder_id=1, new_folder=new_folder, current_user=current_user)
+    
+    db.add.assert_called()
+    db.commit.assert_called()
+    mock_os.mkdir.assert_called_once()
+    assert result.display_name == "Subfolder"
+
+def test_delete_folder_from_db(db):
+    """Test delete_folder_from_db."""
+    folder_id = 1
+    
+    mock_execute = db.execute.return_value
+    mock_scalars = mock_execute.scalars.return_value
+    mock_scalars.all.return_value = [1, 2, 3] # Folder IDs
+    
+    delete_folder_from_db(db, folder_id)
+    
+    assert db.execute.call_count == 3
+    db.commit.assert_called_once()
+
+def test_delete_folder_from_db_empty(db):
+    """Test delete_folder_from_db when no folders found."""
+    folder_id = 1
+    
+    mock_execute = db.execute.return_value
+    mock_scalars = mock_execute.scalars.return_value
+    mock_scalars.all.return_value = []
+    
+    delete_folder_from_db(db, folder_id)
+    
+    assert db.execute.call_count == 1
+    db.commit.assert_not_called()

--- a/src/tests/datastores/user_test.py
+++ b/src/tests/datastores/user_test.py
@@ -26,6 +26,7 @@ from datastores.sql.crud.user import (
 from datastores.sql.models.user import User
 from api.v1 import schemas
 
+
 def test_get_users_from_db(db):
     """Test get_users_from_db."""
     mock_query = db.query.return_value
@@ -36,6 +37,7 @@ def test_get_users_from_db(db):
     db.query.assert_called_once_with(User)
     assert len(result) == 1
     assert result[0].id == 1
+
 
 def test_get_user_from_db(db):
     """Test get_user_from_db."""
@@ -52,6 +54,7 @@ def test_get_user_from_db(db):
     mock_query.filter.assert_called_once()
     assert result.id == user_id
 
+
 def test_create_user_in_db(mocker, db):
     """Test create_user_in_db."""
     mock_get_group = mocker.patch("datastores.sql.crud.user.get_group_by_name_from_db")
@@ -64,7 +67,7 @@ def test_create_user_in_db(mocker, db):
         auth_method="local",
         uuid=uuid.uuid4(),
     )
-    
+
     # Mock "Everyone" group
     mock_group = mocker.MagicMock()
     mock_get_group.return_value = mock_group
@@ -76,6 +79,7 @@ def test_create_user_in_db(mocker, db):
     db.refresh.assert_called()
     assert result.username == "testuser"
     assert mock_group in result.groups
+
 
 def test_search_users(db):
     """Test search_users."""

--- a/src/tests/datastores/user_test.py
+++ b/src/tests/datastores/user_test.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for user CRUD operations."""
+
+import uuid
+import pytest
+
+from datastores.sql.crud.user import (
+    get_users_from_db,
+    get_user_from_db,
+    create_user_in_db,
+    search_users,
+)
+from datastores.sql.models.user import User
+from api.v1 import schemas
+
+def test_get_users_from_db(db):
+    """Test get_users_from_db."""
+    mock_query = db.query.return_value
+    mock_query.all.return_value = [User(id=1)]
+
+    result = get_users_from_db(db)
+
+    db.query.assert_called_once_with(User)
+    assert len(result) == 1
+    assert result[0].id == 1
+
+def test_get_user_from_db(db):
+    """Test get_user_from_db."""
+    user_id = 1
+    mock_query = db.query.return_value
+    mock_filter = mock_query.filter.return_value
+    mock_filter.first.return_value = User(id=user_id)
+
+    result = get_user_from_db(db, user_id)
+
+    db.query.assert_called_once_with(User)
+    # filter condition is User.id == user_id, which is an expression.
+    # We can't easily assert the exact expression object, but we can assert filter was called.
+    mock_query.filter.assert_called_once()
+    assert result.id == user_id
+
+def test_create_user_in_db(mocker, db):
+    """Test create_user_in_db."""
+    mock_get_group = mocker.patch("datastores.sql.crud.user.get_group_by_name_from_db")
+    new_user = schemas.UserCreate(
+        username="testuser",
+        display_name="Test User",
+        email="test@example.com",
+        password_hash="hash",
+        password_hash_algorithm="argon2id",
+        auth_method="local",
+        uuid=uuid.uuid4(),
+    )
+    
+    # Mock "Everyone" group
+    mock_group = mocker.MagicMock()
+    mock_get_group.return_value = mock_group
+
+    result = create_user_in_db(db, new_user)
+
+    db.add.assert_called()
+    db.commit.assert_called()
+    db.refresh.assert_called()
+    assert result.username == "testuser"
+    assert mock_group in result.groups
+
+def test_search_users(db):
+    """Test search_users."""
+    search_str = "test"
+    mock_query = db.query.return_value
+    mock_filter = mock_query.filter.return_value
+    mock_filter.all.return_value = [User(username="testuser")]
+
+    result = search_users(db, search_str)
+
+    db.query.assert_called_once_with(User)
+    mock_query.filter.assert_called_once()
+    assert len(result) == 1
+    assert result[0].username == "testuser"

--- a/src/tests/datastores/workflow_test.py
+++ b/src/tests/datastores/workflow_test.py
@@ -33,27 +33,30 @@ from datastores.sql.crud.workflow import (
 )
 from datastores.sql.models.workflow import Workflow, WorkflowTemplate, Task, TaskReport
 
+
 def test_get_workflow_from_db(mocker):
     """Test get_workflow_from_db."""
     mock_db = mocker.MagicMock()
     mock_workflow = mocker.MagicMock(spec=Workflow)
-    mock_db.get.return_value = mock_workflow    
+    mock_db.get.return_value = mock_workflow
     result = get_workflow_from_db(mock_db, 123)
-    
+
     mock_db.get.assert_called_once_with(Workflow, 123)
     assert result == mock_workflow
+
 
 def test_delete_workflow_from_db(mocker):
     """Test delete_workflow_from_db."""
     mock_db = mocker.MagicMock()
     mock_workflow = mocker.MagicMock(spec=Workflow)
     mock_db.get.return_value = mock_workflow
-    
+
     delete_workflow_from_db(mock_db, 123)
-    
+
     mock_db.get.assert_called_once_with(Workflow, 123)
     mock_db.delete.assert_called_once_with(mock_workflow)
     mock_db.commit.assert_called_once()
+
 
 def test_get_file_workflows_from_db(mocker):
     """Test get_file_workflows_from_db."""
@@ -62,11 +65,12 @@ def test_get_file_workflows_from_db(mocker):
     mock_file = mocker.MagicMock()
     mock_file.workflows = ["workflow1", "workflow2"]
     mock_get_file.return_value = mock_file
-    
+
     result = get_file_workflows_from_db(mock_db, 1)
-    
+
     mock_get_file.assert_called_once_with(mock_db, 1)
     assert result == ["workflow1", "workflow2"]
+
 
 def test_get_folder_workflows_from_db(mocker):
     """Test get_folder_workflows_from_db."""
@@ -75,18 +79,19 @@ def test_get_folder_workflows_from_db(mocker):
     mock_filter = mock_query.filter_by.return_value
     mock_order = mock_filter.order_by.return_value
     mock_order.all.return_value = ["workflow1"]
-    
+
     result = get_folder_workflows_from_db(mock_db, 1)
-    
+
     mock_db.query.assert_called_once_with(Workflow)
     mock_query.filter_by.assert_called_once_with(folder_id=1)
     assert result == ["workflow1"]
+
 
 def test_create_workflow_in_db(mocker):
     """Test create_workflow_in_db."""
     mock_get_file = mocker.patch("datastores.sql.crud.workflow.get_file_from_db")
     mock_uuid = mocker.patch("datastores.sql.crud.workflow.uuid")
-    
+
     mock_db = mocker.MagicMock()
     mock_workflow_schema = mocker.MagicMock()
     mock_workflow_schema.display_name = "test"
@@ -96,64 +101,71 @@ def test_create_workflow_in_db(mocker):
     mock_workflow_schema.folder_id = 1
     mock_workflow_schema.template_id = 1
     mock_workflow_schema.user_id = 1
-    
+
     mock_file = mocker.MagicMock()
     mock_get_file.return_value = mock_file
     mock_uuid.uuid4.return_value = "mocked_uuid"
-    
+
     result = create_workflow_in_db(mock_db, mock_workflow_schema)
-    
+
     mock_db.add.assert_called_once()
     mock_db.commit.assert_called_once()
     mock_db.refresh.assert_called_once()
     assert result is not None
 
+
 def test_update_workflow_in_db(mocker):
     """Test update_workflow_in_db."""
-    mock_get_workflow = mocker.patch("datastores.sql.crud.workflow.get_workflow_from_db")
+    mock_get_workflow = mocker.patch(
+        "datastores.sql.crud.workflow.get_workflow_from_db"
+    )
     mock_db = mocker.MagicMock()
     mock_workflow_in_db = mocker.MagicMock()
     mock_get_workflow.return_value = mock_workflow_in_db
-    
+
     mock_workflow_schema = mocker.MagicMock()
     mock_workflow_schema.model_dump.return_value = {"display_name": "new_name"}
-    
+
     result = update_workflow_in_db(mock_db, mock_workflow_schema)
-    
+
     mock_get_workflow.assert_called_once()
     mock_db.commit.assert_called_once()
     assert result == mock_workflow_in_db
+
 
 def test_delete_workflow_template_from_db(mocker):
     """Test delete_workflow_template_from_db."""
     mock_db = mocker.MagicMock()
     mock_template = mocker.MagicMock()
     mock_db.get.return_value = mock_template
-    
+
     delete_workflow_template_from_db(mock_db, 1)
-    
+
     mock_db.get.assert_called_once_with(WorkflowTemplate, 1)
     mock_db.delete.assert_called_once_with(mock_template)
     mock_db.commit.assert_called_once()
+
 
 def test_delete_workflow_template_from_db_not_found(mocker):
     """Test delete_workflow_template_from_db raising ValueError."""
     mock_db = mocker.MagicMock()
     mock_db.get.return_value = None
-    
+
     with pytest.raises(ValueError):
         delete_workflow_template_from_db(mock_db, 1)
+
 
 def test_get_workflow_template_from_db(mocker):
     """Test get_workflow_template_from_db."""
     mock_db = mocker.MagicMock()
     mock_template = mocker.MagicMock()
     mock_db.get.return_value = mock_template
-    
+
     result = get_workflow_template_from_db(mock_db, 1)
-    
+
     mock_db.get.assert_called_once_with(WorkflowTemplate, 1)
     assert result == mock_template
+
 
 def test_create_workflow_template_in_db(mocker):
     """Test create_workflow_template_in_db."""
@@ -162,39 +174,42 @@ def test_create_workflow_template_in_db(mocker):
     mock_template_schema.display_name = "test"
     mock_template_schema.spec_json = "{}"
     mock_template_schema.user_id = 1
-    
+
     result = create_workflow_template_in_db(mock_db, mock_template_schema)
-    
+
     mock_db.add.assert_called_once()
     mock_db.commit.assert_called_once()
     mock_db.refresh.assert_called_once()
     assert result is not None
+
 
 def test_update_workflow_template_in_db(mocker):
     """Test update_workflow_template_in_db."""
     mock_db = mocker.MagicMock()
     mock_template_in_db = mocker.MagicMock()
     mock_db.get.return_value = mock_template_in_db
-    
+
     mock_template_schema = mocker.MagicMock()
     mock_template_schema.model_dump.return_value = {"display_name": "new_name"}
-    
+
     result = update_workflow_template_in_db(mock_db, mock_template_schema)
-    
+
     mock_db.get.assert_called_once()
     mock_db.commit.assert_called_once()
     assert result == mock_template_in_db
+
 
 def test_get_task_from_db(mocker):
     """Test get_task_from_db."""
     mock_db = mocker.MagicMock()
     mock_task = mocker.MagicMock(spec=Task)
     mock_db.get.return_value = mock_task
-    
+
     result = get_task_from_db(mock_db, "task_id")
-    
+
     mock_db.get.assert_called_once_with(Task, "task_id")
     assert result == mock_task
+
 
 def test_get_task_by_uuid_from_db(mocker):
     """Test get_task_by_uuid_from_db."""
@@ -202,25 +217,27 @@ def test_get_task_by_uuid_from_db(mocker):
     mock_query = mock_db.query.return_value
     mock_filter = mock_query.filter_by.return_value
     mock_filter.first.return_value = "mock_task"
-    
+
     my_uuid = str(uuid.uuid4())
     result = get_task_by_uuid_from_db(mock_db, my_uuid)
-    
+
     mock_db.query.assert_called_once_with(Task)
     mock_query.filter_by.assert_called_once_with(uuid=uuid.UUID(my_uuid))
     assert result == "mock_task"
+
 
 def test_create_task_in_db(mocker):
     """Test create_task_in_db."""
     mock_db = mocker.MagicMock()
     mock_task = mocker.MagicMock()
-    
+
     result = create_task_in_db(mock_db, mock_task)
-    
+
     mock_db.add.assert_called_once_with(mock_task)
     mock_db.commit.assert_called_once()
     mock_db.refresh.assert_called_once_with(mock_task)
     assert result == mock_task
+
 
 def test_create_task_report_in_db(mocker):
     """Test create_task_report_in_db."""
@@ -229,42 +246,45 @@ def test_create_task_report_in_db(mocker):
     mock_report_schema.summary = "sum"
     mock_report_schema.priority = "P0"
     mock_report_schema.markdown = "md"
-    
+
     result = create_task_report_in_db(mock_db, mock_report_schema, 1)
-    
+
     mock_db.add.assert_called_once()
     mock_db.commit.assert_called_once()
     mock_db.refresh.assert_called_once()
     assert result is not None
 
+
 def test_get_workflow_templates_from_db(mocker):
     """Test get_workflow_templates_from_db."""
-    mock_add_unique_params = mocker.patch("datastores.sql.crud.workflow.workflow_utils.add_unique_parameter_names")
+    mock_add_unique_params = mocker.patch(
+        "datastores.sql.crud.workflow.workflow_utils.add_unique_parameter_names"
+    )
     mock_db = mocker.MagicMock()
-    
+
     # Template 1: No task_config
     temp1 = mocker.MagicMock(spec=WorkflowTemplate)
     temp1.spec_json = "{}"
-    
+
     # Template 2: Has task_config, no param_name
     temp2 = mocker.MagicMock(spec=WorkflowTemplate)
     temp2.spec_json = '{"task_config": []}'
-    
+
     # Template 3: Has both (should skip update)
     temp3 = mocker.MagicMock(spec=WorkflowTemplate)
     temp3.spec_json = '{"task_config": [], "param_name": "foo"}'
-    
+
     # Template 4: Invalid JSON
     temp4 = mocker.MagicMock(spec=WorkflowTemplate)
 
     temp4.spec_json = '{"task_config": invalid}'
-    
+
     mock_query = mock_db.query.return_value
     mock_order = mock_query.order_by.return_value
     mock_order.all.return_value = [temp1, temp2, temp3, temp4]
-    
+
     result = get_workflow_templates_from_db(mock_db)
-    
+
     assert len(result) == 4
     # temp2 should be updated
     mock_add_unique_params.assert_called_once()

--- a/src/tests/datastores/workflow_test.py
+++ b/src/tests/datastores/workflow_test.py
@@ -1,0 +1,272 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import uuid
+from datastores.sql.crud.workflow import (
+    get_workflow_from_db,
+    delete_workflow_from_db,
+    get_file_workflows_from_db,
+    get_folder_workflows_from_db,
+    create_workflow_in_db,
+    update_workflow_in_db,
+    delete_workflow_template_from_db,
+    get_workflow_template_from_db,
+    create_workflow_template_in_db,
+    update_workflow_template_in_db,
+    get_task_from_db,
+    get_task_by_uuid_from_db,
+    create_task_in_db,
+    create_task_report_in_db,
+    get_workflow_templates_from_db,
+)
+from datastores.sql.models.workflow import Workflow, WorkflowTemplate, Task, TaskReport
+
+def test_get_workflow_from_db(mocker):
+    """Test get_workflow_from_db."""
+    mock_db = mocker.MagicMock()
+    mock_workflow = mocker.MagicMock(spec=Workflow)
+    mock_db.get.return_value = mock_workflow    
+    result = get_workflow_from_db(mock_db, 123)
+    
+    mock_db.get.assert_called_once_with(Workflow, 123)
+    assert result == mock_workflow
+
+def test_delete_workflow_from_db(mocker):
+    """Test delete_workflow_from_db."""
+    mock_db = mocker.MagicMock()
+    mock_workflow = mocker.MagicMock(spec=Workflow)
+    mock_db.get.return_value = mock_workflow
+    
+    delete_workflow_from_db(mock_db, 123)
+    
+    mock_db.get.assert_called_once_with(Workflow, 123)
+    mock_db.delete.assert_called_once_with(mock_workflow)
+    mock_db.commit.assert_called_once()
+
+def test_get_file_workflows_from_db(mocker):
+    """Test get_file_workflows_from_db."""
+    mock_get_file = mocker.patch("datastores.sql.crud.workflow.get_file_from_db")
+    mock_db = mocker.MagicMock()
+    mock_file = mocker.MagicMock()
+    mock_file.workflows = ["workflow1", "workflow2"]
+    mock_get_file.return_value = mock_file
+    
+    result = get_file_workflows_from_db(mock_db, 1)
+    
+    mock_get_file.assert_called_once_with(mock_db, 1)
+    assert result == ["workflow1", "workflow2"]
+
+def test_get_folder_workflows_from_db(mocker):
+    """Test get_folder_workflows_from_db."""
+    mock_db = mocker.MagicMock()
+    mock_query = mock_db.query.return_value
+    mock_filter = mock_query.filter_by.return_value
+    mock_order = mock_filter.order_by.return_value
+    mock_order.all.return_value = ["workflow1"]
+    
+    result = get_folder_workflows_from_db(mock_db, 1)
+    
+    mock_db.query.assert_called_once_with(Workflow)
+    mock_query.filter_by.assert_called_once_with(folder_id=1)
+    assert result == ["workflow1"]
+
+def test_create_workflow_in_db(mocker):
+    """Test create_workflow_in_db."""
+    mock_get_file = mocker.patch("datastores.sql.crud.workflow.get_file_from_db")
+    mock_uuid = mocker.patch("datastores.sql.crud.workflow.uuid")
+    
+    mock_db = mocker.MagicMock()
+    mock_workflow_schema = mocker.MagicMock()
+    mock_workflow_schema.display_name = "test"
+    mock_workflow_schema.description = "desc"
+    mock_workflow_schema.spec_json = "{}"
+    mock_workflow_schema.file_ids = [1]
+    mock_workflow_schema.folder_id = 1
+    mock_workflow_schema.template_id = 1
+    mock_workflow_schema.user_id = 1
+    
+    mock_file = mocker.MagicMock()
+    mock_get_file.return_value = mock_file
+    mock_uuid.uuid4.return_value = "mocked_uuid"
+    
+    result = create_workflow_in_db(mock_db, mock_workflow_schema)
+    
+    mock_db.add.assert_called_once()
+    mock_db.commit.assert_called_once()
+    mock_db.refresh.assert_called_once()
+    assert result is not None
+
+def test_update_workflow_in_db(mocker):
+    """Test update_workflow_in_db."""
+    mock_get_workflow = mocker.patch("datastores.sql.crud.workflow.get_workflow_from_db")
+    mock_db = mocker.MagicMock()
+    mock_workflow_in_db = mocker.MagicMock()
+    mock_get_workflow.return_value = mock_workflow_in_db
+    
+    mock_workflow_schema = mocker.MagicMock()
+    mock_workflow_schema.model_dump.return_value = {"display_name": "new_name"}
+    
+    result = update_workflow_in_db(mock_db, mock_workflow_schema)
+    
+    mock_get_workflow.assert_called_once()
+    mock_db.commit.assert_called_once()
+    assert result == mock_workflow_in_db
+
+def test_delete_workflow_template_from_db(mocker):
+    """Test delete_workflow_template_from_db."""
+    mock_db = mocker.MagicMock()
+    mock_template = mocker.MagicMock()
+    mock_db.get.return_value = mock_template
+    
+    delete_workflow_template_from_db(mock_db, 1)
+    
+    mock_db.get.assert_called_once_with(WorkflowTemplate, 1)
+    mock_db.delete.assert_called_once_with(mock_template)
+    mock_db.commit.assert_called_once()
+
+def test_delete_workflow_template_from_db_not_found(mocker):
+    """Test delete_workflow_template_from_db raising ValueError."""
+    mock_db = mocker.MagicMock()
+    mock_db.get.return_value = None
+    
+    with pytest.raises(ValueError):
+        delete_workflow_template_from_db(mock_db, 1)
+
+def test_get_workflow_template_from_db(mocker):
+    """Test get_workflow_template_from_db."""
+    mock_db = mocker.MagicMock()
+    mock_template = mocker.MagicMock()
+    mock_db.get.return_value = mock_template
+    
+    result = get_workflow_template_from_db(mock_db, 1)
+    
+    mock_db.get.assert_called_once_with(WorkflowTemplate, 1)
+    assert result == mock_template
+
+def test_create_workflow_template_in_db(mocker):
+    """Test create_workflow_template_in_db."""
+    mock_db = mocker.MagicMock()
+    mock_template_schema = mocker.MagicMock()
+    mock_template_schema.display_name = "test"
+    mock_template_schema.spec_json = "{}"
+    mock_template_schema.user_id = 1
+    
+    result = create_workflow_template_in_db(mock_db, mock_template_schema)
+    
+    mock_db.add.assert_called_once()
+    mock_db.commit.assert_called_once()
+    mock_db.refresh.assert_called_once()
+    assert result is not None
+
+def test_update_workflow_template_in_db(mocker):
+    """Test update_workflow_template_in_db."""
+    mock_db = mocker.MagicMock()
+    mock_template_in_db = mocker.MagicMock()
+    mock_db.get.return_value = mock_template_in_db
+    
+    mock_template_schema = mocker.MagicMock()
+    mock_template_schema.model_dump.return_value = {"display_name": "new_name"}
+    
+    result = update_workflow_template_in_db(mock_db, mock_template_schema)
+    
+    mock_db.get.assert_called_once()
+    mock_db.commit.assert_called_once()
+    assert result == mock_template_in_db
+
+def test_get_task_from_db(mocker):
+    """Test get_task_from_db."""
+    mock_db = mocker.MagicMock()
+    mock_task = mocker.MagicMock(spec=Task)
+    mock_db.get.return_value = mock_task
+    
+    result = get_task_from_db(mock_db, "task_id")
+    
+    mock_db.get.assert_called_once_with(Task, "task_id")
+    assert result == mock_task
+
+def test_get_task_by_uuid_from_db(mocker):
+    """Test get_task_by_uuid_from_db."""
+    mock_db = mocker.MagicMock()
+    mock_query = mock_db.query.return_value
+    mock_filter = mock_query.filter_by.return_value
+    mock_filter.first.return_value = "mock_task"
+    
+    my_uuid = str(uuid.uuid4())
+    result = get_task_by_uuid_from_db(mock_db, my_uuid)
+    
+    mock_db.query.assert_called_once_with(Task)
+    mock_query.filter_by.assert_called_once_with(uuid=uuid.UUID(my_uuid))
+    assert result == "mock_task"
+
+def test_create_task_in_db(mocker):
+    """Test create_task_in_db."""
+    mock_db = mocker.MagicMock()
+    mock_task = mocker.MagicMock()
+    
+    result = create_task_in_db(mock_db, mock_task)
+    
+    mock_db.add.assert_called_once_with(mock_task)
+    mock_db.commit.assert_called_once()
+    mock_db.refresh.assert_called_once_with(mock_task)
+    assert result == mock_task
+
+def test_create_task_report_in_db(mocker):
+    """Test create_task_report_in_db."""
+    mock_db = mocker.MagicMock()
+    mock_report_schema = mocker.MagicMock()
+    mock_report_schema.summary = "sum"
+    mock_report_schema.priority = "P0"
+    mock_report_schema.markdown = "md"
+    
+    result = create_task_report_in_db(mock_db, mock_report_schema, 1)
+    
+    mock_db.add.assert_called_once()
+    mock_db.commit.assert_called_once()
+    mock_db.refresh.assert_called_once()
+    assert result is not None
+
+def test_get_workflow_templates_from_db(mocker):
+    """Test get_workflow_templates_from_db."""
+    mock_add_unique_params = mocker.patch("datastores.sql.crud.workflow.workflow_utils.add_unique_parameter_names")
+    mock_db = mocker.MagicMock()
+    
+    # Template 1: No task_config
+    temp1 = mocker.MagicMock(spec=WorkflowTemplate)
+    temp1.spec_json = "{}"
+    
+    # Template 2: Has task_config, no param_name
+    temp2 = mocker.MagicMock(spec=WorkflowTemplate)
+    temp2.spec_json = '{"task_config": []}'
+    
+    # Template 3: Has both (should skip update)
+    temp3 = mocker.MagicMock(spec=WorkflowTemplate)
+    temp3.spec_json = '{"task_config": [], "param_name": "foo"}'
+    
+    # Template 4: Invalid JSON
+    temp4 = mocker.MagicMock(spec=WorkflowTemplate)
+
+    temp4.spec_json = '{"task_config": invalid}'
+    
+    mock_query = mock_db.query.return_value
+    mock_order = mock_query.order_by.return_value
+    mock_order.all.return_value = [temp1, temp2, temp3, temp4]
+    
+    result = get_workflow_templates_from_db(mock_db)
+    
+    assert len(result) == 4
+    # temp2 should be updated
+    mock_add_unique_params.assert_called_once()
+    mock_db.add.assert_called_once_with(temp2)
+    mock_db.commit.assert_called_once()


### PR DESCRIPTION
### Summary
This PR introduces unit tests for the datastore abstraction layer, covering database operations for files, folders, users, and workflows.

### Changes
- **File Datastore (`file_test.py`)**: Tests for retrieving files by ID or UUID, creating and deleting files, and managing file summaries, reports, and chat history in the DB.
- **Folder Datastore (`folder_test.py`)**: Tests for folder CRUD operations and relationship management.
- **User Datastore (`user_test.py`)**: Tests for operations related to users in the database.
- **Workflow Datastore (`workflow_test.py`)**: Tests for workflow state persistence and retrieval.