### PR TITLE
feat: add support for external read-only data stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 **/.DS_Store
 .python-version
 Tiltfile
+node_modules/
+package.json
+package-lock.json
+yarn.lock
+CLAUDE.md
+OPENRELIK_DESIGN.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 yarn.lock
 CLAUDE.md
 OPENRELIK_DESIGN.md
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,4 @@
 **/.DS_Store
 .python-version
 Tiltfile
-node_modules/
-package.json
-package-lock.json
-yarn.lock
-CLAUDE.md
-OPENRELIK_DESIGN.md
 .coverage

--- a/README.md
+++ b/README.md
@@ -25,11 +25,30 @@ All endpoints are under `/api/v1/datastores/` and require an authenticated user.
 | `POST` | `/api/v1/datastores/` | Create a new external storage (requires `name`, `mount_point`, optional `description`). Returns `409` if the name already exists. |
 | `GET` | `/api/v1/datastores/{name}` | Get a single external storage by name. |
 | `PATCH` | `/api/v1/datastores/{name}` | Update `mount_point` and/or `description`. |
-| `DELETE` | `/api/v1/datastores/{name}` | Delete a storage configuration. Returns `409` if any files still reference it. |
-| `POST` | `/api/v1/datastores/{name}/files` | Register an existing file into the virtual filesystem. Supply `relative_path` (relative to the mount point), `folder_id`, and optional `display_name`/`extension`. No data is copied; a `File` DB record is created pointing at the original location. |
-| `GET` | `/api/v1/datastores/{name}/browse?path=` | List the contents of a directory inside the storage. `path` is relative to the mount point; omit it to list the root. Returns directories and files with sizes, sorted directories-first. |
+| `DELETE` | `/api/v1/datastores/{name}` | Delete a storage configuration and cascade: all folders mounted to this storage are unmounted and all lazily-registered file records are deleted from the database. Physical files on disk are never touched. |
+| `POST` | `/api/v1/datastores/{name}/files` | Register a single existing file into the virtual filesystem. Supply `relative_path` (relative to the mount point), `folder_id`, and optional `display_name`/`extension`. No data is copied; a `File` DB record is created pointing at the original location. |
+| `GET` | `/api/v1/datastores/{name}/browse?path=` | List the contents of a directory inside the storage. `path` is relative to the mount point; omit it to list the root. Returns entries sorted directories-first, then files, alphabetically within each group. |
 
 Path traversal (`..` components and symlink escapes) is rejected with `400` on both the register and browse endpoints.
+
+### Folder-Level Mount
+
+A folder can be mounted directly to an external storage path, after which file listing automatically registers all files in that directory tree as `File` DB records on first access (lazy registration).
+
+**PATCH /api/v1/folders/{id}** accepts two new fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `external_storage_name` | `string` \| `null` | Name of a configured `ExternalStorage`. Set to mount; send `null` to unmount. |
+| `external_base_path` | `string` \| `null` | Optional subdirectory relative to the storage mount point. `null` or omitted means the root of the mount. |
+
+Both fields are also returned in `GET /api/v1/folders/{id}` responses.
+
+**GET /api/v1/folders/{id}/files/** — when the folder has an active mount, this endpoint walks the external directory tree recursively (via `os.walk`, symlinks not followed) and registers any files not yet in the database before returning the file list. Registration is idempotent: files already present are skipped. The relative path stored for each file is relative to the storage mount point, not to `external_base_path`.
+
+**Unmounting** — sending `PATCH /api/v1/folders/{id}` with `external_storage_name: null` removes all lazily-registered file records for that folder from the database. Physical files are not affected.
+
+**Deleting a storage** cascades in the same way: all mounted folders are unmounted and all associated file records are deleted. The deletion uses Core-style SQL throughout to ensure soft-deleted records are also cleaned up.
 
 ### Database Changes
 
@@ -50,7 +69,16 @@ The table also inherits the standard `BaseModel` columns (`id`, `created_at`, `u
 | `external_storage_name` | `UnicodeText` FK → `externalstorage.name` | Set when the file lives in an external store; `NULL` for normal files. |
 | `external_relative_path` | `UnicodeText` (nullable) | Path relative to `ExternalStorage.mount_point`. |
 
-A derived property `is_external` returns `True` when `external_storage_name` is set.
+A derived property `is_external` returns `True` when `external_storage_name` is set. Both `is_external` and `external_relative_path` are included in `FileResponseCompactList` so that the frontend can render read-only badges correctly on folder file listings and across page refreshes.
+
+A unique constraint on `(folder_id, external_storage_name, external_relative_path)` prevents duplicate registrations under concurrent requests.
+
+**New columns on `Folder`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `external_storage_name` | `UnicodeText` FK → `externalstorage.name` (nullable, indexed) | Storage this folder is mounted to, or `NULL` if not mounted. |
+| `external_base_path` | `UnicodeText` (nullable) | Subdirectory within the storage to use as the root for this mount. `NULL` means the storage mount point root. |
 
 ### How It Works
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All endpoints are under `/api/v1/datastores/` and require an authenticated user.
 | `POST` | `/api/v1/datastores/{name}/files` | Register a single existing file into the virtual filesystem. Supply `relative_path` (relative to the mount point), `folder_id`, and optional `display_name`/`extension`. No data is copied; a `File` DB record is created pointing at the original location. |
 | `GET` | `/api/v1/datastores/{name}/browse?path=` | List the contents of a directory inside the storage. `path` is relative to the mount point; omit it to list the root. Returns entries sorted directories-first, then files, alphabetically within each group. |
 
-Path traversal (`..` components and symlink escapes) is rejected with `400` on both the register and browse endpoints.
+Path traversal (`..` components and symlink escapes) is rejected with `400` on both the register and browse endpoints. Symlink files and symlink directories are skipped in both the browse listing and the lazy-registration sync, so symlinks are never registered as `File` records.
 
 ### Folder-Level Mount
 
@@ -88,4 +88,4 @@ A unique constraint on `(folder_id, external_storage_name, external_relative_pat
 2. **Explicit storage provider** (`storage_provider` is set): looks up the provider's base path from config and joins it with `storage_key`.
 3. **Default** (most files): constructs `folder.path / <uuid>[.extension]` using the parent folder's path recursively.
 
-On soft-delete, the standard SQLAlchemy `after_delete` event removes the file from disk for normal files. External files are skipped — the listener returns early when `external_storage_name` is set, so the original data on the mount is never touched.
+When a `File` ORM object is hard-deleted via `db.delete()`, the standard SQLAlchemy `after_delete` listener removes the physical file from disk for normal files. External files are skipped — the listener returns early when `external_storage_name` is set, so the original data on the mount is never touched. For soft-deletes (bulk `UPDATE … SET is_deleted = TRUE`), the listener never fires, so no disk I/O occurs for either file type.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,58 @@ OpenRelik is an open-source (Apache-2.0) platform designed to streamline collabo
 
 ##### Obligatory Fine Print
 This is not an official Google product (experimental or otherwise), it is just code that happens to be owned by Google.
+
+---
+
+## External Read-Only Data Stores
+
+### Overview
+
+External read-only data stores let you register files from locations that already exist on disk — SMB shares, NFS mounts, pre-existing case storage — without copying any data into the main OpenRelik volume. An `ExternalStorage` record maps a logical name (e.g. `case_smb`) to an absolute mount point on the host/container (e.g. `/mnt/cases`). Files registered from that store are treated as read-only references: workers can read them as normal `File` objects, but the platform never writes to or deletes them from disk.
+
+### API Endpoints
+
+All endpoints are under `/api/v1/datastores/` and require an authenticated user.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/datastores/` | List all configured external storage locations. |
+| `POST` | `/api/v1/datastores/` | Create a new external storage (requires `name`, `mount_point`, optional `description`). Returns `409` if the name already exists. |
+| `GET` | `/api/v1/datastores/{name}` | Get a single external storage by name. |
+| `PATCH` | `/api/v1/datastores/{name}` | Update `mount_point` and/or `description`. |
+| `DELETE` | `/api/v1/datastores/{name}` | Delete a storage configuration. Returns `409` if any files still reference it. |
+| `POST` | `/api/v1/datastores/{name}/files` | Register an existing file into the virtual filesystem. Supply `relative_path` (relative to the mount point), `folder_id`, and optional `display_name`/`extension`. No data is copied; a `File` DB record is created pointing at the original location. |
+| `GET` | `/api/v1/datastores/{name}/browse?path=` | List the contents of a directory inside the storage. `path` is relative to the mount point; omit it to list the root. Returns directories and files with sizes, sorted directories-first. |
+
+Path traversal (`..` components and symlink escapes) is rejected with `400` on both the register and browse endpoints.
+
+### Database Changes
+
+**New table — `ExternalStorage`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `name` | `UnicodeText` | Unique logical identifier (primary lookup key). |
+| `mount_point` | `UnicodeText` | Absolute path on the host/container. |
+| `description` | `UnicodeText` (nullable) | Human-readable label. |
+
+The table also inherits the standard `BaseModel` columns (`id`, `created_at`, `updated_at`, `is_deleted`).
+
+**New columns on `File`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `external_storage_name` | `UnicodeText` FK → `externalstorage.name` | Set when the file lives in an external store; `NULL` for normal files. |
+| `external_relative_path` | `UnicodeText` (nullable) | Path relative to `ExternalStorage.mount_point`. |
+
+A derived property `is_external` returns `True` when `external_storage_name` is set.
+
+### How It Works
+
+`File.path` is a `hybrid_property` that resolves the on-disk location at runtime:
+
+1. **External file** (`external_storage_name` is set): returns `mount_point / external_relative_path`, after validating that there are no `..` components. The `ExternalStorage` relationship must be eagerly loaded for this to work.
+2. **Explicit storage provider** (`storage_provider` is set): looks up the provider's base path from config and joins it with `storage_key`.
+3. **Default** (most files): constructs `folder.path / <uuid>[.extension]` using the parent folder's path recursively.
+
+On soft-delete, the standard SQLAlchemy `after_delete` event removes the file from disk for normal files. External files are skipped — the listener returns early when `external_storage_name` is set, so the original data on the mount is never touched.

--- a/src/api/v1/external_storages.py
+++ b/src/api/v1/external_storages.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 logger = logging.getLogger(__name__)
 
 from auth.common import get_current_active_user
+from datastores.sql.crud import authz as crud_authz
 from datastores.sql.crud.external_storage import (
     create_external_storage_in_db,
     delete_external_storage_from_db,
@@ -30,7 +31,9 @@ from datastores.sql.crud.external_storage import (
     register_external_file_in_db,
     update_external_storage_in_db,
 )
+from datastores.sql.crud.folder import get_folder_from_db
 from datastores.sql.database import get_db_connection
+from datastores.sql.models.role import Role
 
 from . import schemas
 
@@ -227,6 +230,10 @@ def browse_external_storage(
 
     items = []
     for entry in os.scandir(resolved):
+        # Skip all symlinks — consistent with the recursive sync which also skips
+        # symlink files and does not follow symlink directories.
+        if entry.is_symlink():
+            continue
         if entry.is_dir(follow_symlinks=False):
             items.append(schemas.BrowseItem(name=entry.name, type="directory", size=None))
         else:
@@ -266,6 +273,14 @@ def register_external_file(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"External storage '{storage_name}' not found.",
         )
+
+    folder = get_folder_from_db(db, request.folder_id)
+    if folder is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Folder {request.folder_id} not found.",
+        )
+    crud_authz.check_user_access(db, current_user, [Role.EDITOR, Role.OWNER], folder=folder)
 
     _validate_no_traversal(request.relative_path)
     physical_path = _resolve_and_validate_path(storage.mount_point, request.relative_path)

--- a/src/api/v1/external_storages.py
+++ b/src/api/v1/external_storages.py
@@ -148,18 +148,19 @@ def delete_external_storage(
     db: Session = Depends(get_db_connection),
     current_user: schemas.User = Depends(get_current_active_user),
 ):
-    """Delete an external storage. Fails with 409 if files still reference it."""
+    """Delete an external storage and cascade all references.
+
+    Any folders mounted to this storage are unmounted (external_storage_name set to
+    null) and any lazily-registered File records that point to this storage are
+    deleted from the database.  Physical files on disk are never touched.
+    """
     storage = get_external_storage_from_db(db, storage_name)
     if not storage:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"External storage '{storage_name}' not found.",
         )
-    if not delete_external_storage_from_db(db, storage):
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Cannot delete: files are still referencing this external storage.",
-        )
+    delete_external_storage_from_db(db, storage)
 
 
 # --- Browse ---

--- a/src/api/v1/external_storages.py
+++ b/src/api/v1/external_storages.py
@@ -1,0 +1,289 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+from auth.common import get_current_active_user
+from datastores.sql.crud.external_storage import (
+    create_external_storage_in_db,
+    delete_external_storage_from_db,
+    get_external_storage_from_db,
+    get_external_storages_from_db,
+    register_external_file_in_db,
+    update_external_storage_in_db,
+)
+from datastores.sql.database import get_db_connection
+
+from . import schemas
+
+router = APIRouter()
+
+
+def _validate_no_traversal(relative_path: str) -> None:
+    """Raise HTTP 400 if relative_path contains '..' components."""
+    parts = relative_path.replace("\\", "/").split("/")
+    if ".." in parts:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path traversal detected in relative_path.",
+        )
+
+
+def _resolve_and_validate_path(mount_point: str, relative_path: str) -> str:
+    """Resolve relative_path against mount_point and ensure it stays inside.
+
+    Returns the resolved absolute path.
+
+    Raises:
+        HTTPException 400 if the resolved path escapes the mount point, does not
+        exist, or is not a regular file.
+    """
+    joined = os.path.join(mount_point, relative_path.lstrip("/"))
+    resolved = os.path.realpath(joined)
+    mount_real = os.path.realpath(mount_point)
+
+    # Ensure the resolved path stays inside the mount point.
+    if resolved != mount_real and not resolved.startswith(mount_real + os.sep):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Resolved path escapes the mount point.",
+        )
+    if not os.path.exists(resolved):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The specified path does not exist on disk.",
+        )
+    if not os.path.isfile(resolved):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The specified path is not a regular file.",
+        )
+    return resolved
+
+
+# --- ExternalStorage CRUD ---
+
+@router.get("/", response_model=List[schemas.ExternalStorageResponse])
+def list_external_storages(
+    db: Session = Depends(get_db_connection),
+    current_user: schemas.User = Depends(get_current_active_user),
+):
+    """List all configured external storage locations."""
+    return get_external_storages_from_db(db)
+
+
+@router.post(
+    "/",
+    response_model=schemas.ExternalStorageResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_external_storage(
+    storage: schemas.ExternalStorageCreate,
+    db: Session = Depends(get_db_connection),
+    current_user: schemas.User = Depends(get_current_active_user),
+):
+    """Create a new external storage configuration."""
+    if get_external_storage_from_db(db, storage.name):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"External storage '{storage.name}' already exists.",
+        )
+    return create_external_storage_in_db(db, storage)
+
+
+@router.get("/{storage_name}", response_model=schemas.ExternalStorageResponse)
+def get_external_storage(
+    storage_name: str,
+    db: Session = Depends(get_db_connection),
+    current_user: schemas.User = Depends(get_current_active_user),
+):
+    """Get a single external storage by name."""
+    storage = get_external_storage_from_db(db, storage_name)
+    if not storage:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"External storage '{storage_name}' not found.",
+        )
+    return storage
+
+
+@router.patch("/{storage_name}", response_model=schemas.ExternalStorageResponse)
+def update_external_storage(
+    storage_name: str,
+    update_data: schemas.ExternalStorageUpdate,
+    db: Session = Depends(get_db_connection),
+    current_user: schemas.User = Depends(get_current_active_user),
+):
+    """Update mount_point and/or description of an external storage."""
+    storage = get_external_storage_from_db(db, storage_name)
+    if not storage:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"External storage '{storage_name}' not found.",
+        )
+    return update_external_storage_in_db(db, storage, update_data)
+
+
+@router.delete("/{storage_name}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_external_storage(
+    storage_name: str,
+    db: Session = Depends(get_db_connection),
+    current_user: schemas.User = Depends(get_current_active_user),
+):
+    """Delete an external storage. Fails with 409 if files still reference it."""
+    storage = get_external_storage_from_db(db, storage_name)
+    if not storage:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"External storage '{storage_name}' not found.",
+        )
+    if not delete_external_storage_from_db(db, storage):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot delete: files are still referencing this external storage.",
+        )
+
+
+# --- Browse ---
+
+@router.get("/{storage_name}/browse", response_model=schemas.BrowseResponse)
+def browse_external_storage(
+    storage_name: str,
+    path: str = "",
+    db: Session = Depends(get_db_connection),
+    current_user: schemas.User = Depends(get_current_active_user),
+):
+    """Browse a directory inside an external storage.
+
+    Query parameter ``path`` is relative to the storage mount point.  When
+    omitted the mount-point root is listed.
+    """
+    logger.debug("browse: storage_name=%r path=%r", storage_name, path)
+
+    storage = get_external_storage_from_db(db, storage_name)
+    if not storage:
+        # get_external_storage_from_db logs a WARNING if the row exists but is
+        # soft-deleted (is_deleted=True); here we just propagate the 404.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"External storage '{storage_name}' not found.",
+        )
+
+    logger.debug("browse: found storage id=%s mount_point=%r is_deleted=%s",
+                 storage.id, storage.mount_point, storage.is_deleted)
+
+    _validate_no_traversal(path)
+
+    mount_real = os.path.realpath(storage.mount_point)
+    joined = os.path.join(mount_real, path.lstrip("/"))
+    resolved = os.path.realpath(joined)
+
+    logger.debug("browse: mount_real=%r joined=%r resolved=%r", mount_real, joined, resolved)
+
+    # Ensure resolved path stays inside the mount point.
+    if resolved != mount_real and not resolved.startswith(mount_real + os.sep):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Resolved path escapes the mount point.",
+        )
+
+    path_exists = os.path.exists(resolved)
+    logger.debug("browse: os.path.exists(%r)=%s", resolved, path_exists)
+    if not path_exists:
+        logger.warning(
+            "browse: resolved path %r does not exist (mount_point=%r, path=%r). "
+            "Check that the filesystem is mounted and the server process has read access.",
+            resolved, storage.mount_point, path,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The specified path does not exist.",
+        )
+
+    if not os.path.isdir(resolved):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The specified path is not a directory.",
+        )
+
+    items = []
+    for entry in os.scandir(resolved):
+        if entry.is_dir(follow_symlinks=False):
+            items.append(schemas.BrowseItem(name=entry.name, type="directory", size=None))
+        else:
+            try:
+                size = entry.stat(follow_symlinks=False).st_size
+            except OSError:
+                size = None
+            items.append(schemas.BrowseItem(name=entry.name, type="file", size=size))
+
+    # Directories first, then files; alphabetically within each group.
+    items.sort(key=lambda i: (0 if i.type == "directory" else 1, i.name))
+
+    return schemas.BrowseResponse(current_path=path, items=items)
+
+
+# --- External file registration ---
+
+@router.post(
+    "/{storage_name}/files",
+    response_model=schemas.FileResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def register_external_file(
+    storage_name: str,
+    request: schemas.ExternalFileRegisterRequest,
+    db: Session = Depends(get_db_connection),
+    current_user: schemas.User = Depends(get_current_active_user),
+):
+    """Register an existing file from external storage into the VFS.
+
+    Creates a File DB record pointing to the file without copying any data.
+    The file is treated as read-only by all workers.
+    """
+    storage = get_external_storage_from_db(db, storage_name)
+    if not storage:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"External storage '{storage_name}' not found.",
+        )
+
+    _validate_no_traversal(request.relative_path)
+    physical_path = _resolve_and_validate_path(storage.mount_point, request.relative_path)
+
+    filename = os.path.basename(request.relative_path)
+    display_name = request.display_name or filename
+
+    extension = request.extension
+    if not extension:
+        _, ext = os.path.splitext(filename)
+        extension = ext.lstrip(".") if ext else ""
+
+    return register_external_file_in_db(
+        db=db,
+        storage=storage,
+        relative_path=request.relative_path,
+        physical_path=physical_path,
+        folder_id=request.folder_id,
+        display_name=display_name,
+        extension=extension,
+        current_user=current_user,
+    )

--- a/src/api/v1/folders.py
+++ b/src/api/v1/folders.py
@@ -14,6 +14,8 @@
 
 import asyncio
 import json
+import logging
+import os
 import uuid
 from typing import List
 
@@ -25,7 +27,10 @@ from sse_starlette import EventSourceResponse
 import config
 from auth.common import get_current_active_user
 from datastores.sql.crud.authz import check_user_access, require_access
-from datastores.sql.crud.file import get_files_from_db
+from datastores.sql.crud.external_storage import get_external_storage_from_db
+from datastores.sql.crud.file import get_files_from_db, sync_external_mount_files_in_db
+
+logger = logging.getLogger(__name__)
 from datastores.sql.crud.folder import (
     create_root_folder_in_db,
     create_subfolder_in_db,
@@ -59,6 +64,36 @@ from lib.stream_manager import stream_manager
 from . import schemas
 
 router = APIRouter()
+
+
+def _validate_external_base_path(mount_point: str, base_path: str) -> None:
+    """Validate that base_path is safe and points to a directory inside mount_point.
+
+    Args:
+        mount_point: Absolute path of the ExternalStorage mount.
+        base_path: Relative path within the mount to validate.
+
+    Raises:
+        HTTPException 400: If path traversal is detected, the path escapes the mount,
+                           or the resolved path is not a directory.
+    """
+    if ".." in base_path.replace("\\", "/").split("/"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path traversal not allowed in external_base_path.",
+        )
+    resolved = os.path.realpath(os.path.join(mount_point, base_path.lstrip("/")))
+    mount_real = os.path.realpath(mount_point)
+    if resolved != mount_real and not resolved.startswith(mount_real + os.sep):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="external_base_path escapes the mount point.",
+        )
+    if not os.path.isdir(resolved):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"external_base_path '{base_path}' is not a directory.",
+        )
 
 
 # Get all root folders for a user
@@ -257,14 +292,24 @@ async def update_folder(
     Raises:
         HTTPException: If the user does not have permission to update it.
     """
-    folder_from_db = get_folder_from_db(db, folder_id)
-    folder_model = schemas.FolderCreate(**folder_from_db.__dict__)
+    # Validate external mount fields if provided
+    if folder_from_request.external_storage_name is not None:
+        storage = get_external_storage_from_db(db, folder_from_request.external_storage_name)
+        if not storage:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"External storage '{folder_from_request.external_storage_name}' not found.",
+            )
+        if folder_from_request.external_base_path:
+            _validate_external_base_path(
+                storage.mount_point, folder_from_request.external_base_path
+            )
 
-    # Update folder data with supplied values
-    update_data = folder_from_request.model_dump(exclude_unset=True)
-    updated_folder_model = folder_model.model_copy(update=update_data)
+    # Normalize empty string to None for canonical storage
+    if folder_from_request.external_base_path == "":
+        folder_from_request.external_base_path = None
 
-    return update_folder_in_db(db, updated_folder_model)
+    return update_folder_in_db(db, folder_id, folder_from_request)
 
 
 # Get files for a folder
@@ -275,6 +320,18 @@ def get_folder_files(
     db: Session = Depends(get_db_connection),
     current_user: schemas.User = Depends(get_current_active_user),
 ) -> List[schemas.FileResponseCompactList]:
+    folder = get_folder_from_db(db, folder_id)
+    if folder is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found.")
+
+    if folder.external_storage_name:
+        try:
+            sync_external_mount_files_in_db(db, folder, current_user)
+        except ValueError as exc:
+            logger.warning(
+                "External mount sync failed for folder %s: %s", folder_id, exc
+            )
+
     return get_files_from_db(db, folder_id)
 
 

--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -194,6 +194,42 @@ class GroupRoleResponse(BaseSchema):
     role: str
 
 
+# ExternalStorage schemas
+class ExternalStorageCreate(BaseModel):
+    name: str
+    mount_point: str
+    description: Optional[str] = None
+
+
+class ExternalStorageUpdate(BaseModel):
+    mount_point: Optional[str] = None
+    description: Optional[str] = None
+
+
+class ExternalStorageResponse(BaseSchema):
+    name: str
+    mount_point: str
+    description: Optional[str] = None
+
+
+class ExternalFileRegisterRequest(BaseModel):
+    folder_id: int
+    relative_path: str
+    display_name: Optional[str] = None
+    extension: Optional[str] = None
+
+
+class BrowseItem(BaseModel):
+    name: str
+    type: str  # "file" or "directory"
+    size: Optional[int] = None
+
+
+class BrowseResponse(BaseModel):
+    current_path: str
+    items: List[BrowseItem]
+
+
 # File schemas
 class FileCreate(BaseModel):
     display_name: str
@@ -214,6 +250,8 @@ class FileCreate(BaseModel):
     folder_id: Optional[int] = None
     task_output_id: Optional[int] = None
     source_file_id: Optional[int] = None
+    external_storage_name: Optional[str] = None
+    external_relative_path: Optional[str] = None
 
 
 class FileResponseCompact(BaseSchemaCompact):
@@ -241,6 +279,10 @@ class FileResponse(BaseSchema):
     hash_ssdeep: Optional[str] = None
     storage_provider: Optional[str] = None
     storage_key: Optional[str] = None
+    # External (read-only) storage fields. is_external=True means the file must not be written.
+    is_external: bool = False
+    external_storage_name: Optional[str] = None
+    external_relative_path: Optional[str] = None
     user_id: int
     user: UserResponseCompact
     folder: Optional[FolderResponse] = None

--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -155,8 +155,6 @@ class FolderShareRequest(BaseModel):
 class FolderCreate(BaseSchema):
     display_name: str
     parent_id: Optional[int] = None
-    external_storage_name: Optional[str] = None
-    external_base_path: Optional[str] = None
 
 
 class FolderResponse(BaseSchema):

--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -138,7 +138,9 @@ class FolderCreateRequest(BaseModel):
 
 
 class FolderUpdateRequest(BaseModel):
-    display_name: str
+    display_name: Optional[str] = None
+    external_storage_name: Optional[str] = None
+    external_base_path: Optional[str] = None
 
 
 class FolderShareRequest(BaseModel):
@@ -153,6 +155,8 @@ class FolderShareRequest(BaseModel):
 class FolderCreate(BaseSchema):
     display_name: str
     parent_id: Optional[int] = None
+    external_storage_name: Optional[str] = None
+    external_base_path: Optional[str] = None
 
 
 class FolderResponse(BaseSchema):
@@ -166,6 +170,8 @@ class FolderResponse(BaseSchema):
     user_roles: Optional[List["UserRoleResponse"]]
     group_roles: Optional[List["GroupRoleResponse"]]
     storage_provider: Optional[str] = None
+    external_storage_name: Optional[str] = None
+    external_base_path: Optional[str] = None
 
 
 class FolderResponseCompact(BaseSchema):
@@ -303,6 +309,7 @@ class FileResponseCompactList(BaseModel):
     updated_at: Optional[datetime] = None
     is_deleted: Optional[bool] = False
     is_external: bool = False
+    external_relative_path: Optional[str] = None
 
 
 class FileSummaryCreate(BaseModel):

--- a/src/api/v1/schemas.py
+++ b/src/api/v1/schemas.py
@@ -302,6 +302,7 @@ class FileResponseCompactList(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     is_deleted: Optional[bool] = False
+    is_external: bool = False
 
 
 class FileSummaryCreate(BaseModel):

--- a/src/datastores/sql/alembic/env.py
+++ b/src/datastores/sql/alembic/env.py
@@ -6,6 +6,7 @@ from sqlalchemy import create_engine
 
 # Import OpenRelik models so Alembic finds them.
 from datastores.sql.database import BaseModel
+from datastores.sql.models.external_storage import ExternalStorage
 from datastores.sql.models.file import (
     File,
     FileAttribute,

--- a/src/datastores/sql/alembic/versions/b20df176dd1b_add_external_mount_to_folder.py
+++ b/src/datastores/sql/alembic/versions/b20df176dd1b_add_external_mount_to_folder.py
@@ -1,0 +1,103 @@
+"""Add external mount fields to folder model
+
+Revision ID: b20df176dd1b
+Revises: e3f1a2b4c5d6
+Create Date: 2026-04-15 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b20df176dd1b"
+down_revision: Union[str, None] = "e3f1a2b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add external mount columns to the folder table
+    op.add_column("folder", sa.Column("external_storage_name", sa.UnicodeText(), nullable=True))
+    op.add_column("folder", sa.Column("external_base_path", sa.UnicodeText(), nullable=True))
+    op.create_index(
+        op.f("ix_folder_external_storage_name"),
+        "folder",
+        ["external_storage_name"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "fk_folder_external_storage_name",
+        "folder",
+        "externalstorage",
+        ["external_storage_name"],
+        ["name"],
+    )
+    # Remove duplicate external file rows before adding the unique constraint,
+    # keeping only the row with the highest id for each
+    # (folder_id, external_storage_name, external_relative_path) combination.
+    # Rows where any of the three columns is NULL are not duplicates by definition
+    # (NULL != NULL), so we filter them out of the dedup query.
+    # Related userrole rows must be deleted first to satisfy the FK constraint.
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            WITH dup_ids AS (
+                SELECT id
+                FROM file
+                WHERE folder_id IS NOT NULL
+                  AND external_storage_name IS NOT NULL
+                  AND external_relative_path IS NOT NULL
+                  AND id NOT IN (
+                      SELECT MAX(id)
+                      FROM file
+                      WHERE folder_id IS NOT NULL
+                        AND external_storage_name IS NOT NULL
+                        AND external_relative_path IS NOT NULL
+                      GROUP BY folder_id, external_storage_name, external_relative_path
+                  )
+            )
+            DELETE FROM userrole WHERE file_id IN (SELECT id FROM dup_ids)
+            """
+        )
+    )
+    conn.execute(
+        sa.text(
+            """
+            WITH dup_ids AS (
+                SELECT id
+                FROM file
+                WHERE folder_id IS NOT NULL
+                  AND external_storage_name IS NOT NULL
+                  AND external_relative_path IS NOT NULL
+                  AND id NOT IN (
+                      SELECT MAX(id)
+                      FROM file
+                      WHERE folder_id IS NOT NULL
+                        AND external_storage_name IS NOT NULL
+                        AND external_relative_path IS NOT NULL
+                      GROUP BY folder_id, external_storage_name, external_relative_path
+                  )
+            )
+            DELETE FROM file WHERE id IN (SELECT id FROM dup_ids)
+            """
+        )
+    )
+
+    # Unique constraint on file table to prevent duplicate lazy registrations.
+    # NULL != NULL in PostgreSQL unique constraints, so regular files (where these
+    # columns are NULL) are unaffected — only external file rows are constrained.
+    op.create_unique_constraint(
+        "uq_file_folder_external",
+        "file",
+        ["folder_id", "external_storage_name", "external_relative_path"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_file_folder_external", "file", type_="unique")
+    op.drop_constraint("fk_folder_external_storage_name", "folder", type_="foreignkey")
+    op.drop_index(op.f("ix_folder_external_storage_name"), table_name="folder")
+    op.drop_column("folder", "external_base_path")
+    op.drop_column("folder", "external_storage_name")

--- a/src/datastores/sql/alembic/versions/e3f1a2b4c5d6_add_external_storage.py
+++ b/src/datastores/sql/alembic/versions/e3f1a2b4c5d6_add_external_storage.py
@@ -1,0 +1,90 @@
+"""Add ExternalStorage model and external file fields
+
+Revision ID: e3f1a2b4c5d6
+Revises: 49974ebaed96
+Create Date: 2026-04-14 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e3f1a2b4c5d6"
+down_revision: Union[str, None] = "49974ebaed96"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create the externalstorage table.
+    op.create_table(
+        "externalstorage",
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "is_deleted",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("purged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "is_purged",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("name", sa.UnicodeText(), nullable=False),
+        sa.Column("mount_point", sa.UnicodeText(), nullable=False),
+        sa.Column("description", sa.UnicodeText(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_externalstorage_name"), "externalstorage", ["name"], unique=True
+    )
+
+    # Add external storage columns to the file table.
+    op.add_column(
+        "file",
+        sa.Column("external_storage_name", sa.UnicodeText(), nullable=True),
+    )
+    op.add_column(
+        "file",
+        sa.Column("external_relative_path", sa.UnicodeText(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_file_external_storage_name"),
+        "file",
+        ["external_storage_name"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "fk_file_external_storage_name",
+        "file",
+        "externalstorage",
+        ["external_storage_name"],
+        ["name"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_file_external_storage_name", "file", type_="foreignkey")
+    op.drop_index(op.f("ix_file_external_storage_name"), table_name="file")
+    op.drop_column("file", "external_relative_path")
+    op.drop_column("file", "external_storage_name")
+
+    op.drop_index(op.f("ix_externalstorage_name"), table_name="externalstorage")
+    op.drop_table("externalstorage")

--- a/src/datastores/sql/crud/external_storage.py
+++ b/src/datastores/sql/crud/external_storage.py
@@ -18,13 +18,21 @@ import uuid as uuid_module
 from typing import List, Optional
 
 import magic
+from sqlalchemy import delete as sql_delete
+from sqlalchemy import select as sql_select
+from sqlalchemy import update as sql_update
 from sqlalchemy.orm import Session
 
 from api.v1 import schemas
 from datastores.sql.models.external_storage import ExternalStorage
 
 logger = logging.getLogger(__name__)
-from datastores.sql.models.file import File
+from datastores.sql.models.file import (
+    File,
+    file_task_input_association_table,
+    file_workflow_association_table,
+)
+from datastores.sql.models.group import GroupRole
 from datastores.sql.models.role import Role
 from datastores.sql.models.user import UserRole
 
@@ -84,16 +92,73 @@ def update_external_storage_in_db(
 
 
 def delete_external_storage_from_db(db: Session, db_storage: ExternalStorage) -> bool:
-    """Delete an ExternalStorage if no File records reference it.
+    """Cascade-delete an ExternalStorage and all references to it.
+
+    All steps use Core-style SQL so that the before_compile soft-delete filter
+    (added by the global SQLAlchemy event listener in database.py) is bypassed.
+    This ensures soft-deleted files and folders are cleaned up too.
+
+    Before deleting the ExternalStorage record:
+      1. Unmount all folders that reference this storage (set external_storage_name
+         and external_base_path to NULL).
+      2. Delete all File records that reference this storage in FK-safe order:
+         nullify source_file_id back-references, remove junction rows, remove
+         UserRole/GroupRole rows, then DELETE the File rows.
+         Physical files on disk are never touched — we intentionally skip the
+         ORM path (and the after_delete event) because external files must not
+         be deleted from disk.
 
     Returns:
-        True if deleted, False if files still reference this storage.
+        True (always — the storage is deleted unconditionally).
     """
-    file_count = (
-        db.query(File).filter(File.external_storage_name == db_storage.name).count()
+    from datastores.sql.models.folder import Folder
+
+    storage_name = db_storage.name
+
+    # 1. Unmount all folders (Core UPDATE bypasses before_compile soft-delete filter).
+    db.execute(
+        sql_update(Folder)
+        .where(Folder.external_storage_name == storage_name)
+        .values(external_storage_name=None, external_base_path=None)
     )
-    if file_count > 0:
-        return False
+
+    # 2a. Collect all File ids using Core SELECT — bypasses the before_compile
+    #     soft-delete filter so soft-deleted external files are included.
+    result = db.execute(
+        sql_select(File.id).where(File.external_storage_name == storage_name)
+    )
+    external_file_ids = [row[0] for row in result]
+
+    if external_file_ids:
+        # 2b. Nullify self-referential FK from derived files pointing to these files.
+        db.execute(
+            sql_update(File)
+            .where(File.source_file_id.in_(external_file_ids))
+            .values(source_file_id=None)
+        )
+
+        # 2c. Remove junction-table rows.
+        db.execute(
+            sql_delete(file_task_input_association_table).where(
+                file_task_input_association_table.c.file_id.in_(external_file_ids)
+            )
+        )
+        db.execute(
+            sql_delete(file_workflow_association_table).where(
+                file_workflow_association_table.c.file_id.in_(external_file_ids)
+            )
+        )
+
+        # 2d. Delete non-cascade permission rows.
+        db.execute(sql_delete(UserRole).where(UserRole.file_id.in_(external_file_ids)))
+        db.execute(sql_delete(GroupRole).where(GroupRole.file_id.in_(external_file_ids)))
+
+        # 2e. Core DELETE on File rows — bypasses before_compile and after_delete,
+        #     so physical files are never touched (correct for external files).
+        #     Lazily-registered files have no attributes/summaries/chats/reports,
+        #     so there are no child FK rows to clean up before this DELETE.
+        db.execute(sql_delete(File).where(File.id.in_(external_file_ids)))
+
     db.delete(db_storage)
     db.commit()
     return True

--- a/src/datastores/sql/crud/external_storage.py
+++ b/src/datastores/sql/crud/external_storage.py
@@ -1,0 +1,155 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import uuid as uuid_module
+from typing import List, Optional
+
+import magic
+from sqlalchemy.orm import Session
+
+from api.v1 import schemas
+from datastores.sql.models.external_storage import ExternalStorage
+
+logger = logging.getLogger(__name__)
+from datastores.sql.models.file import File
+from datastores.sql.models.role import Role
+from datastores.sql.models.user import UserRole
+
+
+def get_external_storages_from_db(db: Session) -> List[ExternalStorage]:
+    """Retrieve all configured external storages ordered by id."""
+    return db.query(ExternalStorage).order_by(ExternalStorage.id.asc()).all()
+
+
+def get_external_storage_from_db(db: Session, name: str) -> Optional[ExternalStorage]:
+    """Retrieve a single ExternalStorage by its unique name."""
+    # NOTE: the global before_compile listener in database.py automatically appends
+    #   WHERE (is_deleted = FALSE OR is_deleted IS NULL)
+    # to every query on entities that have is_deleted.  If the row exists but has
+    # is_deleted = TRUE it will be silently filtered out and this function returns None.
+    result = db.query(ExternalStorage).filter_by(name=name).first()
+    if result is None:
+        # Diagnostic: bypass the soft-delete filter to check whether the row exists at all.
+        bypass_query = db.query(ExternalStorage).filter(ExternalStorage.name == name)
+        bypass_query._include_deleted = True  # Tells before_compile to skip the filter.
+        raw = bypass_query.first()
+        if raw is not None:
+            logger.warning(
+                "get_external_storage_from_db: row name=%r exists in DB but is excluded "
+                "by the soft-delete filter (is_deleted=%s). "
+                "Fix: reset is_deleted=False on the record.",
+                name,
+                raw.is_deleted,
+            )
+        else:
+            logger.debug("get_external_storage_from_db: no row at all found for name=%r", name)
+    return result
+
+
+def create_external_storage_in_db(
+    db: Session, storage: schemas.ExternalStorageCreate
+) -> ExternalStorage:
+    """Create a new ExternalStorage record."""
+    db_storage = ExternalStorage(**storage.model_dump())
+    db.add(db_storage)
+    db.commit()
+    db.refresh(db_storage)
+    return db_storage
+
+
+def update_external_storage_in_db(
+    db: Session,
+    db_storage: ExternalStorage,
+    update_data: schemas.ExternalStorageUpdate,
+) -> ExternalStorage:
+    """Update mount_point and/or description of an ExternalStorage."""
+    for key, value in update_data.model_dump(exclude_unset=True).items():
+        setattr(db_storage, key, value)
+    db.commit()
+    db.refresh(db_storage)
+    return db_storage
+
+
+def delete_external_storage_from_db(db: Session, db_storage: ExternalStorage) -> bool:
+    """Delete an ExternalStorage if no File records reference it.
+
+    Returns:
+        True if deleted, False if files still reference this storage.
+    """
+    file_count = (
+        db.query(File).filter(File.external_storage_name == db_storage.name).count()
+    )
+    if file_count > 0:
+        return False
+    db.delete(db_storage)
+    db.commit()
+    return True
+
+
+def register_external_file_in_db(
+    db: Session,
+    storage: ExternalStorage,
+    relative_path: str,
+    physical_path: str,
+    folder_id: int,
+    display_name: str,
+    extension: str,
+    current_user,
+) -> File:
+    """Create a File DB record that references an existing file in external storage.
+
+    No data is copied. The record points to the file via external_storage_name and
+    external_relative_path. The file is treated as read-only by workers.
+
+    Args:
+        db: SQLAlchemy session.
+        storage: The ExternalStorage the file belongs to.
+        relative_path: Path relative to storage.mount_point.
+        physical_path: Resolved absolute path on disk (used for stat/magic).
+        folder_id: VFS folder that should contain this file.
+        display_name: Human-readable name for the file.
+        extension: File extension (without leading dot).
+        current_user: Authenticated user (ORM User model or object with .id).
+
+    Returns:
+        The newly created File ORM object.
+    """
+    filename = os.path.basename(relative_path)
+    file_uuid = uuid_module.uuid4()
+
+    db_file = File(
+        display_name=display_name,
+        uuid=file_uuid,
+        filename=filename,
+        filesize=os.path.getsize(physical_path),
+        extension=extension,
+        data_type="file:generic",
+        magic_text=magic.from_file(physical_path),
+        magic_mime=magic.from_file(physical_path, mime=True),
+        folder_id=folder_id,
+        user_id=current_user.id,
+        external_storage_name=storage.name,
+        external_relative_path=relative_path,
+    )
+    db.add(db_file)
+    db.commit()
+    db.refresh(db_file)
+
+    user_role = UserRole(user=current_user, file=db_file, role=Role.OWNER)
+    db.add(user_role)
+    db.commit()
+
+    return db_file

--- a/src/datastores/sql/crud/file.py
+++ b/src/datastores/sql/crud/file.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import uuid
 
 import magic
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
 
 from api.v1 import schemas
 from datastores.sql.models.file import File, FileChat, FileChatMessage, FileReport, FileSummary
@@ -37,6 +41,90 @@ def get_files_from_db(db: Session, folder_id: int):
         List[File]: A list of File objects representing the files in the folder.
     """
     return db.query(File).filter_by(folder_id=folder_id).order_by(File.id.desc()).all()
+
+
+def sync_external_mount_files_in_db(db: Session, folder, current_user) -> None:
+    """Lazily register files from a folder's external mount into the DB.
+
+    Recursively walks the directory at
+    (ExternalStorage.mount_point / folder.external_base_path) and creates File
+    DB records for any regular files not already registered. Idempotent.
+    Symbolic links are skipped. Symbolic-link directories are not followed.
+
+    Args:
+        db: SQLAlchemy session.
+        folder: Folder ORM object with external_storage_name set.
+        current_user: Authenticated user assigned as owner of newly created records.
+
+    Raises:
+        ValueError: If the storage is not found, the path escapes the mount point,
+                    or the resolved path is not a directory.
+    """
+    from datastores.sql.crud.external_storage import (
+        get_external_storage_from_db,
+        register_external_file_in_db,
+    )
+
+    storage = get_external_storage_from_db(db, folder.external_storage_name)
+    if not storage:
+        raise ValueError(f"External storage '{folder.external_storage_name}' not found.")
+
+    base = folder.external_base_path or ""
+    resolved_dir = os.path.realpath(os.path.join(storage.mount_point, base.lstrip("/")))
+    mount_real = os.path.realpath(storage.mount_point)
+
+    if resolved_dir != mount_real and not resolved_dir.startswith(mount_real + os.sep):
+        raise ValueError(
+            f"external_base_path '{base}' escapes mount point '{storage.mount_point}'."
+        )
+    if not os.path.isdir(resolved_dir):
+        raise ValueError(f"External base path '{resolved_dir}' is not a directory.")
+
+    # Pre-load existing registered paths in a single query to avoid N+1 on large trees.
+    existing_paths = {
+        row.external_relative_path
+        for row in db.query(File.external_relative_path)
+        .filter_by(folder_id=folder.id, external_storage_name=folder.external_storage_name)
+        .all()
+    }
+
+    for dirpath, _dirnames, filenames in os.walk(resolved_dir, followlinks=False):
+        for filename in filenames:
+            physical_path = os.path.join(dirpath, filename)
+
+            # Skip symbolic links — consistent with the original scandir behaviour.
+            if os.path.islink(physical_path):
+                continue
+
+            # relative_path is always relative to mount_point, so nested files
+            # naturally include their subdirectory prefix (e.g. "evidence/file.bin").
+            relative_path = os.path.relpath(physical_path, storage.mount_point)
+            if relative_path in existing_paths:
+                continue
+
+            display_name = filename
+            _, ext = os.path.splitext(filename)
+            extension = ext.lstrip(".") if ext else ""
+            try:
+                register_external_file_in_db(
+                    db,
+                    storage,
+                    relative_path,
+                    physical_path,
+                    folder.id,
+                    display_name,
+                    extension,
+                    current_user,
+                )
+            except IntegrityError:
+                # Another concurrent request registered the same file — safe to ignore.
+                db.rollback()
+                logger.debug(
+                    "sync_external_mount: IntegrityError for '%s' in folder %s "
+                    "(concurrent insert)",
+                    relative_path,
+                    folder.id,
+                )
 
 
 def get_file_from_db(db: Session, file_id: int):

--- a/src/datastores/sql/crud/file.py
+++ b/src/datastores/sql/crud/file.py
@@ -70,6 +70,13 @@ def sync_external_mount_files_in_db(db: Session, folder, current_user) -> None:
         raise ValueError(f"External storage '{folder.external_storage_name}' not found.")
 
     base = folder.external_base_path or ""
+
+    # Explicit '..' check mirrors the browse endpoint's _validate_no_traversal.
+    if ".." in base.replace("\\", "/").split("/"):
+        raise ValueError(
+            f"external_base_path '{base}' contains path traversal components."
+        )
+
     resolved_dir = os.path.realpath(os.path.join(storage.mount_point, base.lstrip("/")))
     mount_real = os.path.realpath(storage.mount_point)
 
@@ -80,12 +87,20 @@ def sync_external_mount_files_in_db(db: Session, folder, current_user) -> None:
     if not os.path.isdir(resolved_dir):
         raise ValueError(f"External base path '{resolved_dir}' is not a directory.")
 
-    # Pre-load existing registered paths in a single query to avoid N+1 on large trees.
+    # Pre-load existing registered paths using Core SQL so that soft-deleted
+    # records are included.  The ORM query path adds WHERE is_deleted = FALSE
+    # via the global before_compile listener, which would cause duplicates for
+    # any path whose previous record was soft-deleted.
+    import sqlalchemy as sa
+
     existing_paths = {
-        row.external_relative_path
-        for row in db.query(File.external_relative_path)
-        .filter_by(folder_id=folder.id, external_storage_name=folder.external_storage_name)
-        .all()
+        row[0]
+        for row in db.execute(
+            sa.select(File.external_relative_path).where(
+                File.folder_id == folder.id,
+                File.external_storage_name == storage.name,
+            )
+        ).fetchall()
     }
 
     for dirpath, _dirnames, filenames in os.walk(resolved_dir, followlinks=False):

--- a/src/datastores/sql/crud/folder.py
+++ b/src/datastores/sql/crud/folder.py
@@ -15,12 +15,16 @@
 import os
 import uuid
 
-from sqlalchemy import and_, func, select, union, update
+from sqlalchemy import and_, delete as sql_delete, func, select, union, update
 from sqlalchemy.orm import Session, aliased
 
 from api.v1 import schemas
 from config import config
-from datastores.sql.models.file import File
+from datastores.sql.models.file import (
+    File,
+    file_task_input_association_table,
+    file_workflow_association_table,
+)
 from datastores.sql.models.folder import Folder
 from datastores.sql.models.group import Group, GroupRole
 from datastores.sql.models.role import Role
@@ -366,22 +370,99 @@ def create_subfolder_in_db(
     return new_db_folder
 
 
-def update_folder_in_db(db: Session, folder: schemas.FolderUpdateRequest):
+def _delete_external_files_for_folder(db: Session, folder_id: int) -> None:
+    """Hard-delete all lazily-registered external File records for a folder.
+
+    Called when a folder's external mount is cleared.  Physical files are
+    never touched — the ``after_delete`` event on File returns early for
+    external files, and the bulk Core deletes below bypass that event
+    entirely while only targeting rows where external_storage_name IS NOT NULL.
+
+    Deletion order respects FK constraints:
+      1. Nullify ``source_file_id`` on any files derived from these files.
+      2. Remove rows from the task-input and workflow junction tables.
+      3. Delete UserRole and GroupRole rows (no cascade on these relationships).
+      4. ORM-delete each File, which cascades ``attributes``, ``summaries``,
+         ``chats``, and ``reports`` automatically.
+    """
+    # ORM query; before_compile adds is_deleted filter — intentionally skips
+    # already-soft-deleted external files (they are already "logically gone").
+    external_file_ids = [
+        row[0]
+        for row in db.query(File.id)
+        .filter(File.folder_id == folder_id, File.external_storage_name.isnot(None))
+        .all()
+    ]
+    if not external_file_ids:
+        return
+
+    # 1. Nullify self-referential FK from derived files pointing to these files.
+    db.query(File).filter(File.source_file_id.in_(external_file_ids)).update(
+        {"source_file_id": None}, synchronize_session=False
+    )
+
+    # 2. Remove junction-table rows (Core delete bypasses before_compile — fine
+    #    because we want to remove these regardless of soft-delete status).
+    db.execute(
+        sql_delete(file_task_input_association_table).where(
+            file_task_input_association_table.c.file_id.in_(external_file_ids)
+        )
+    )
+    db.execute(
+        sql_delete(file_workflow_association_table).where(
+            file_workflow_association_table.c.file_id.in_(external_file_ids)
+        )
+    )
+
+    # 3. Delete non-cascade permission rows.
+    db.execute(sql_delete(UserRole).where(UserRole.file_id.in_(external_file_ids)))
+    db.execute(sql_delete(GroupRole).where(GroupRole.file_id.in_(external_file_ids)))
+
+    # 4. ORM-delete each File so cascade removes attributes/summaries/chats/reports.
+    #    after_delete fires but returns early for external files — no disk I/O.
+    for file_obj in db.query(File).filter(File.id.in_(external_file_ids)).all():
+        db.delete(file_obj)
+
+    db.commit()
+
+
+def update_folder_in_db(
+    db: Session, folder_id: int, folder: schemas.FolderUpdateRequest
+) -> Folder:
     """Update a folder in the database.
 
+    Only fields explicitly present in the request body are written — including
+    null values, which clear the corresponding column.  This is achieved by
+    iterating over ``folder.model_fields_set`` instead of ``model_dump()``, so
+    fields that were absent from the request are left unchanged.
+
+    When ``external_storage_name`` is explicitly set to ``None`` (unmounting),
+    all lazily-registered external File records for this folder are deleted
+    from the database.  Physical files on disk are not affected.
+
     Args:
-        db (Session): SQLAlchemy session object
-        folder (dict): Updated dictionary of a folder
+        db (Session): SQLAlchemy session object.
+        folder_id (int): Primary key of the folder to update.
+        folder (FolderUpdateRequest): Parsed request body.  Only
+            ``folder.model_fields_set`` keys are applied.
 
     Returns:
-        Folder object
+        Updated Folder ORM object.
     """
-    folder_in_db = db.get(Folder, folder.id)
-    folder_dict = folder.model_dump()
-    for key, value in folder_dict.items():
-        setattr(folder_in_db, key, value) if value else None
+    unmounting = (
+        "external_storage_name" in folder.model_fields_set
+        and folder.external_storage_name is None
+    )
+
+    folder_in_db = db.get(Folder, folder_id)
+    for key in folder.model_fields_set:
+        setattr(folder_in_db, key, getattr(folder, key))
     db.commit()
     db.refresh(folder_in_db)
+
+    if unmounting:
+        _delete_external_files_for_folder(db, folder_id)
+
     return folder_in_db
 
 

--- a/src/datastores/sql/crud/folder.py
+++ b/src/datastores/sql/crud/folder.py
@@ -457,6 +457,10 @@ def update_folder_in_db(
     folder_in_db = db.get(Folder, folder_id)
     for key in folder.model_fields_set:
         setattr(folder_in_db, key, getattr(folder, key))
+    if unmounting:
+        # Always clear the base path when unmounting, even if the client did not
+        # explicitly include external_base_path in the request body.
+        folder_in_db.external_base_path = None
     db.commit()
     db.refresh(folder_in_db)
 

--- a/src/datastores/sql/models/external_storage.py
+++ b/src/datastores/sql/models/external_storage.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sqlalchemy import UnicodeText
+
+from ..database import BaseModel
+
+
+class ExternalStorage(BaseModel):
+    """Represents a read-only external storage location.
+
+    External storages are host/container mount points (e.g. SMB or NFS shares)
+    that already contain files which should be referenced by the platform without
+    copying data into the main storage volume.
+
+    Attributes:
+        name (str): Unique logical identifier, e.g. "case_smb_storage".
+        mount_point (str): Absolute path on the host/container, e.g. "/mnt/cases".
+        description (Optional[str]): Human-readable description of this storage.
+    """
+
+    name: Mapped[str] = mapped_column(UnicodeText, index=True, unique=True)
+    mount_point: Mapped[str] = mapped_column(UnicodeText, index=False)
+    description: Mapped[Optional[str]] = mapped_column(UnicodeText, index=False, nullable=True)

--- a/src/datastores/sql/models/file.py
+++ b/src/datastores/sql/models/file.py
@@ -38,6 +38,8 @@ from ..database import (
     FeedbackMixin,
 )
 
+from .external_storage import ExternalStorage
+
 if TYPE_CHECKING:
     from .folder import Folder
     from .group import GroupRole
@@ -116,6 +118,18 @@ class File(BaseModel):
     storage_provider: Mapped[str] = mapped_column(UnicodeText, index=True, nullable=True)
     storage_key: Mapped[Optional[str]] = mapped_column(UnicodeText, index=True)
 
+    # External (read-only) storage: when set, the file lives in an ExternalStorage mount rather
+    # than the main data volume. external_relative_path is relative to ExternalStorage.mount_point.
+    external_storage_name: Mapped[Optional[str]] = mapped_column(
+        UnicodeText,
+        ForeignKey("externalstorage.name"),
+        index=True,
+        nullable=True,
+    )
+    external_relative_path: Mapped[Optional[str]] = mapped_column(
+        UnicodeText, index=False, nullable=True
+    )
+
     # Relationships
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
     user: Mapped["User"] = relationship(back_populates="files")
@@ -179,16 +193,55 @@ class File(BaseModel):
     user_roles: Mapped[List["UserRole"]] = relationship(back_populates="file")
     group_roles: Mapped[List["GroupRole"]] = relationship(back_populates="file")
 
+    # Relationship to the external storage config (None for regular files).
+    external_storage: Mapped[Optional["ExternalStorage"]] = relationship(
+        "ExternalStorage",
+        foreign_keys=[external_storage_name],
+    )
+
+    @property
+    def is_external(self) -> bool:
+        """Returns True if this file lives in a read-only external storage."""
+        return self.external_storage_name is not None
+
     @hybrid_property
     def path(self):
         """Returns the full path of the file.
+
+        For external files the path is:
+            ExternalStorage.mount_point / external_relative_path
+
+        For files with an explicit storage provider the path is:
+            provider_base_path / storage_key
+
+        For all other files (default case) the path is:
+            folder.path / uuid[.extension]
 
         Returns:
             str: The full path of the file.
 
         Raises:
-            ValueError: If no storage provider is configured or no storage key is set for the file.
+            ValueError: If path resolution fails (missing config, missing key, path traversal).
         """
+        # --- External (read-only) storage ---
+        if self.external_storage_name is not None:
+            if self.external_storage is None:
+                raise ValueError(
+                    f"External storage '{self.external_storage_name}' not found in database."
+                )
+            if not self.external_relative_path:
+                raise ValueError("No relative path set for external file.")
+            parts = self.external_relative_path.replace("\\", "/").split("/")
+            if ".." in parts:
+                raise ValueError(
+                    "Path traversal detected in external_relative_path: "
+                    f"'{self.external_relative_path}'."
+                )
+            return os.path.join(
+                self.external_storage.mount_point,
+                self.external_relative_path.lstrip("/"),
+            )
+
         full_path = None
         storage_provider_configs = config.get("server", {}).get("storage", {}).get("providers", {})
 
@@ -490,7 +543,10 @@ class FileChatMessageFeedback(BaseModel, FeedbackMixin):
 
 
 # Delete file from the filesystem when the database row is deleted.
+# External files are never removed from disk — they are read-only references.
 @event.listens_for(File, "after_delete")
 def delete_file_after_row_delete(mapper, connection, file_to_delete):
+    if file_to_delete.external_storage_name is not None:
+        return
     if os.path.exists(file_to_delete.path):
         os.remove(file_to_delete.path)

--- a/src/datastores/sql/models/file.py
+++ b/src/datastores/sql/models/file.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     Table,
     Unicode,
     UnicodeText,
+    UniqueConstraint,
     event,
 )
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -91,6 +92,15 @@ class File(BaseModel):
         workflows (List[Workflow]): The workflows that have been applied to the file.
         summaries (List[FileSummary]): The summaries of the file.
     """
+
+    __table_args__ = (
+        UniqueConstraint(
+            "folder_id",
+            "external_storage_name",
+            "external_relative_path",
+            name="uq_file_folder_external",
+        ),
+    )
 
     display_name: Mapped[Optional[str]] = mapped_column(UnicodeText, index=True)
     description: Mapped[Optional[str]] = mapped_column(UnicodeText, index=False)

--- a/src/datastores/sql/models/folder.py
+++ b/src/datastores/sql/models/folder.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from config import get_config
+from datastores.sql.models.external_storage import ExternalStorage
 from datastores.sql.models.workflow import Workflow
 
 from ..database import AttributeMixin, BaseModel
@@ -55,6 +56,20 @@ class Folder(BaseModel):
     # mount point. Only root-level folders have this set; subfolders inherit the storage provider of
     # their top-level parent folder. This attribute is ignored for subfolders.
     storage_provider: Mapped[str] = mapped_column(UnicodeText, index=True, nullable=True)
+
+    # External mount: when set, GET /folders/{id}/files/ will lazily register all files found
+    # directly under the external directory as read-only File DB records (flat, no recursion).
+    external_storage_name: Mapped[Optional[str]] = mapped_column(
+        UnicodeText,
+        ForeignKey("externalstorage.name"),
+        index=True,
+        nullable=True,
+    )
+    external_base_path: Mapped[Optional[str]] = mapped_column(UnicodeText, nullable=True)
+    external_storage: Mapped[Optional["ExternalStorage"]] = relationship(
+        "ExternalStorage",
+        foreign_keys=[external_storage_name],
+    )
 
     # Relationships
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))

--- a/src/datastores/sql/models/folder.py
+++ b/src/datastores/sql/models/folder.py
@@ -58,7 +58,7 @@ class Folder(BaseModel):
     storage_provider: Mapped[str] = mapped_column(UnicodeText, index=True, nullable=True)
 
     # External mount: when set, GET /folders/{id}/files/ will lazily register all files found
-    # directly under the external directory as read-only File DB records (flat, no recursion).
+    # recursively under the external directory as read-only File DB records.
     external_storage_name: Mapped[Optional[str]] = mapped_column(
         UnicodeText,
         ForeignKey("externalstorage.name"),

--- a/src/main.py
+++ b/src/main.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 from contextlib import asynccontextmanager
+
+# Temporary: enable DEBUG for external-storage modules to diagnose browse 404.
+logging.getLogger("api.v1.external_storages").setLevel(logging.DEBUG)
+logging.getLogger("datastores.sql.crud.external_storage").setLevel(logging.DEBUG)
 
 from celery.app import Celery
 from fastapi import Depends, FastAPI
@@ -24,6 +29,7 @@ from sqlalchemy.exc import ProgrammingError
 from starlette.middleware.sessions import SessionMiddleware
 
 from api.v1 import configs as configs_v1
+from api.v1 import external_storages as external_storages_v1
 from api.v1 import files as files_v1
 from api.v1 import folders as folders_v1
 from api.v1 import groups as groups_v1
@@ -205,6 +211,15 @@ api_v1.include_router(
     metrics_v1.router,
     prefix="/metrics",
     tags=["metrics"],
+    dependencies=[
+        Depends(common_auth.get_current_active_user),
+        Depends(common_auth.verify_csrf),
+    ],
+)
+api_v1.include_router(
+    external_storages_v1.router,
+    prefix="/datastores",
+    tags=["datastores"],
     dependencies=[
         Depends(common_auth.get_current_active_user),
         Depends(common_auth.verify_csrf),

--- a/src/tests/api/v1/external_storages_test.py
+++ b/src/tests/api/v1/external_storages_test.py
@@ -1,0 +1,467 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for external storage CRUD and file registration endpoints."""
+
+import uuid
+
+import pytest
+
+from datastores.sql.models.external_storage import ExternalStorage
+from datastores.sql.models.file import File
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_storage(name="test_store", mount_point="/mnt/cases") -> ExternalStorage:
+    return ExternalStorage(
+        id=1,
+        name=name,
+        mount_point=mount_point,
+        description="Test storage",
+        created_at=None,
+        updated_at=None,
+        deleted_at=None,
+        is_deleted=False,
+    )
+
+
+def _storage_dict(name="test_store", mount_point="/mnt/cases"):
+    return {
+        "id": 1,
+        "name": name,
+        "mount_point": mount_point,
+        "description": "Test storage",
+        "created_at": None,
+        "updated_at": None,
+        "deleted_at": None,
+        "is_deleted": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /datastores/
+# ---------------------------------------------------------------------------
+
+def test_list_external_storages(fastapi_test_client, mocker):
+    mock_list = mocker.patch("api.v1.external_storages.get_external_storages_from_db")
+    mock_list.return_value = [_make_storage()]
+
+    response = fastapi_test_client.get("/datastores/")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "test_store"
+
+
+# ---------------------------------------------------------------------------
+# POST /datastores/
+# ---------------------------------------------------------------------------
+
+def test_create_external_storage_success(fastapi_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db", return_value=None
+    )
+    mock_create = mocker.patch("api.v1.external_storages.create_external_storage_in_db")
+    mock_create.return_value = _make_storage()
+
+    response = fastapi_test_client.post(
+        "/datastores/",
+        json={"name": "test_store", "mount_point": "/mnt/cases", "description": "Test storage"},
+    )
+    assert response.status_code == 201
+    assert response.json()["name"] == "test_store"
+
+
+def test_create_external_storage_conflict(fastapi_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=_make_storage(),
+    )
+    response = fastapi_test_client.post(
+        "/datastores/",
+        json={"name": "test_store", "mount_point": "/mnt/cases"},
+    )
+    assert response.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# GET /datastores/{storage_name}
+# ---------------------------------------------------------------------------
+
+def test_get_external_storage_found(fastapi_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=_make_storage(),
+    )
+    response = fastapi_test_client.get("/datastores/test_store")
+    assert response.status_code == 200
+    assert response.json()["name"] == "test_store"
+
+
+def test_get_external_storage_not_found(fastapi_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db", return_value=None
+    )
+    response = fastapi_test_client.get("/datastores/nonexistent")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /datastores/{storage_name}
+# ---------------------------------------------------------------------------
+
+def test_update_external_storage_success(fastapi_test_client, mocker):
+    updated = _make_storage(mount_point="/mnt/updated")
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=_make_storage(),
+    )
+    mock_update = mocker.patch("api.v1.external_storages.update_external_storage_in_db")
+    mock_update.return_value = updated
+
+    response = fastapi_test_client.patch(
+        "/datastores/test_store",
+        json={"mount_point": "/mnt/updated"},
+    )
+    assert response.status_code == 200
+    assert response.json()["mount_point"] == "/mnt/updated"
+
+
+def test_update_external_storage_not_found(fastapi_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db", return_value=None
+    )
+    response = fastapi_test_client.patch(
+        "/datastores/nonexistent",
+        json={"mount_point": "/mnt/new"},
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /datastores/{storage_name}
+# ---------------------------------------------------------------------------
+
+def test_delete_external_storage_success(fastapi_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=_make_storage(),
+    )
+    mocker.patch(
+        "api.v1.external_storages.delete_external_storage_from_db", return_value=True
+    )
+    response = fastapi_test_client.delete("/datastores/test_store")
+    assert response.status_code == 204
+
+
+def test_delete_external_storage_conflict(fastapi_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=_make_storage(),
+    )
+    mocker.patch(
+        "api.v1.external_storages.delete_external_storage_from_db", return_value=False
+    )
+    response = fastapi_test_client.delete("/datastores/test_store")
+    assert response.status_code == 409
+
+
+def test_delete_external_storage_not_found(fastapi_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db", return_value=None
+    )
+    response = fastapi_test_client.delete("/datastores/nonexistent")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /datastores/{storage_name}/files  — register external file
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_register_external_file_success(
+    fastapi_async_test_client, mocker, tmp_path, file_response
+):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    real_file = mount / "image.dd"
+    real_file.write_bytes(b"\x00" * 16)
+
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+    mock_register = mocker.patch(
+        "api.v1.external_storages.register_external_file_in_db"
+    )
+    mock_register.return_value = file_response
+
+    response = await fastapi_async_test_client.post(
+        "/datastores/test_store/files",
+        json={"folder_id": 1, "relative_path": "image.dd"},
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_register_external_file_path_traversal(
+    fastapi_async_test_client, mocker, tmp_path
+):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.post(
+        "/datastores/test_store/files",
+        json={"folder_id": 1, "relative_path": "../../etc/passwd"},
+    )
+    assert response.status_code == 400
+    assert "traversal" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_register_external_file_path_not_found(
+    fastapi_async_test_client, mocker, tmp_path
+):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.post(
+        "/datastores/test_store/files",
+        json={"folder_id": 1, "relative_path": "nonexistent.dd"},
+    )
+    assert response.status_code == 400
+    assert "does not exist" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_register_external_file_path_is_directory(
+    fastapi_async_test_client, mocker, tmp_path
+):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    subdir = mount / "subdir"
+    subdir.mkdir()
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.post(
+        "/datastores/test_store/files",
+        json={"folder_id": 1, "relative_path": "subdir"},
+    )
+    assert response.status_code == 400
+    assert "not a regular file" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_register_external_file_storage_not_found(
+    fastapi_async_test_client, mocker
+):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db", return_value=None
+    )
+    response = await fastapi_async_test_client.post(
+        "/datastores/nonexistent/files",
+        json={"folder_id": 1, "relative_path": "image.dd"},
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /datastores/{storage_name}/browse
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_browse_root(fastapi_async_test_client, mocker, tmp_path):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    (mount / "image.dd").write_bytes(b"\x00" * 512)
+    (mount / "logs").mkdir()
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get("/datastores/test_store/browse")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_path"] == ""
+    names = [i["name"] for i in data["items"]]
+    # directories come first
+    assert data["items"][0]["type"] == "directory"
+    assert data["items"][0]["name"] == "logs"
+    assert data["items"][1]["type"] == "file"
+    assert data["items"][1]["name"] == "image.dd"
+    assert data["items"][1]["size"] == 512
+
+
+@pytest.mark.asyncio
+async def test_browse_subdir(fastapi_async_test_client, mocker, tmp_path):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    subdir = mount / "evidence"
+    subdir.mkdir()
+    (subdir / "file_a.txt").write_bytes(b"a")
+    (subdir / "file_b.txt").write_bytes(b"bb")
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get(
+        "/datastores/test_store/browse", params={"path": "evidence"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_path"] == "evidence"
+    assert len(data["items"]) == 2
+    assert data["items"][0]["name"] == "file_a.txt"
+    assert data["items"][1]["name"] == "file_b.txt"
+
+
+@pytest.mark.asyncio
+async def test_browse_alphabetical_sort(fastapi_async_test_client, mocker, tmp_path):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    for name in ["zeta.bin", "alpha.bin", "mu.bin"]:
+        (mount / name).write_bytes(b"x")
+    for name in ["zoo", "ant", "middle"]:
+        (mount / name).mkdir()
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get("/datastores/test_store/browse")
+    assert response.status_code == 200
+    items = response.json()["items"]
+    dirs = [i for i in items if i["type"] == "directory"]
+    files = [i for i in items if i["type"] == "file"]
+    # All dirs before all files
+    assert items.index(dirs[-1]) < items.index(files[0])
+    # Each group sorted alphabetically
+    assert [d["name"] for d in dirs] == sorted(d["name"] for d in dirs)
+    assert [f["name"] for f in files] == sorted(f["name"] for f in files)
+
+
+@pytest.mark.asyncio
+async def test_browse_storage_not_found(fastapi_async_test_client, mocker):
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db", return_value=None
+    )
+    response = await fastapi_async_test_client.get("/datastores/nonexistent/browse")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_browse_path_traversal(fastapi_async_test_client, mocker, tmp_path):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get(
+        "/datastores/test_store/browse", params={"path": "../../etc"}
+    )
+    assert response.status_code == 400
+    assert "traversal" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_browse_path_escapes_mount(fastapi_async_test_client, mocker, tmp_path):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    outside = tmp_path / "secret"
+    outside.mkdir()
+    # Create a symlink inside mount that points outside
+    symlink = mount / "escape"
+    symlink.symlink_to(outside)
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get(
+        "/datastores/test_store/browse", params={"path": "escape"}
+    )
+    assert response.status_code == 400
+    assert "escapes" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_browse_path_not_found(fastapi_async_test_client, mocker, tmp_path):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get(
+        "/datastores/test_store/browse", params={"path": "nonexistent"}
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_browse_path_is_file(fastapi_async_test_client, mocker, tmp_path):
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    (mount / "image.dd").write_bytes(b"\x00")
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get(
+        "/datastores/test_store/browse", params={"path": "image.dd"}
+    )
+    assert response.status_code == 400
+    assert "not a directory" in response.json()["detail"].lower()

--- a/src/tests/api/v1/external_storages_test.py
+++ b/src/tests/api/v1/external_storages_test.py
@@ -180,6 +180,25 @@ def test_delete_external_storage_not_found(fastapi_test_client, mocker):
 # POST /datastores/{storage_name}/files  — register external file
 # ---------------------------------------------------------------------------
 
+def _patch_register_deps(mocker, storage, folder=True):
+    """Helper: patch the three dependencies that register_external_file always calls."""
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+    if folder is True:
+        # Return a truthy MagicMock so the 404 guard passes.
+        mocker.patch(
+            "api.v1.external_storages.get_folder_from_db",
+            return_value=mocker.MagicMock(),
+        )
+    else:
+        mocker.patch(
+            "api.v1.external_storages.get_folder_from_db",
+            return_value=folder,
+        )
+
+
 @pytest.mark.asyncio
 async def test_register_external_file_success(
     fastapi_async_test_client, mocker, tmp_path, file_response
@@ -190,11 +209,7 @@ async def test_register_external_file_success(
     real_file.write_bytes(b"\x00" * 16)
 
     storage = _make_storage(mount_point=str(mount))
-
-    mocker.patch(
-        "api.v1.external_storages.get_external_storage_from_db",
-        return_value=storage,
-    )
+    _patch_register_deps(mocker, storage)
     mock_register = mocker.patch(
         "api.v1.external_storages.register_external_file_in_db"
     )
@@ -214,11 +229,7 @@ async def test_register_external_file_path_traversal(
     mount = tmp_path / "cases"
     mount.mkdir()
     storage = _make_storage(mount_point=str(mount))
-
-    mocker.patch(
-        "api.v1.external_storages.get_external_storage_from_db",
-        return_value=storage,
-    )
+    _patch_register_deps(mocker, storage)
 
     response = await fastapi_async_test_client.post(
         "/datastores/test_store/files",
@@ -235,11 +246,7 @@ async def test_register_external_file_path_not_found(
     mount = tmp_path / "cases"
     mount.mkdir()
     storage = _make_storage(mount_point=str(mount))
-
-    mocker.patch(
-        "api.v1.external_storages.get_external_storage_from_db",
-        return_value=storage,
-    )
+    _patch_register_deps(mocker, storage)
 
     response = await fastapi_async_test_client.post(
         "/datastores/test_store/files",
@@ -258,11 +265,7 @@ async def test_register_external_file_path_is_directory(
     subdir = mount / "subdir"
     subdir.mkdir()
     storage = _make_storage(mount_point=str(mount))
-
-    mocker.patch(
-        "api.v1.external_storages.get_external_storage_from_db",
-        return_value=storage,
-    )
+    _patch_register_deps(mocker, storage)
 
     response = await fastapi_async_test_client.post(
         "/datastores/test_store/files",
@@ -453,3 +456,140 @@ async def test_browse_path_is_file(fastapi_async_test_client, mocker, tmp_path):
     )
     assert response.status_code == 400
     assert "not a directory" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_browse_skips_symlink_files(fastapi_async_test_client, mocker, tmp_path):
+    """Symlink files must not appear in browse results (consistent with sync)."""
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    real_file = mount / "real.dd"
+    real_file.write_bytes(b"\x00" * 8)
+    link_file = mount / "link.dd"
+    link_file.symlink_to(real_file)
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get("/datastores/test_store/browse")
+    assert response.status_code == 200
+    names = [i["name"] for i in response.json()["items"]]
+    assert "real.dd" in names
+    assert "link.dd" not in names, "symlink files must be excluded from browse results"
+
+
+@pytest.mark.asyncio
+async def test_browse_skips_symlink_directories(fastapi_async_test_client, mocker, tmp_path):
+    """Symlink directories must not appear in browse results."""
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    (real_dir / "secret.bin").write_bytes(b"x")
+    link_dir = mount / "linked_dir"
+    link_dir.symlink_to(real_dir)
+    storage = _make_storage(mount_point=str(mount))
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+
+    response = await fastapi_async_test_client.get("/datastores/test_store/browse")
+    assert response.status_code == 200
+    names = [i["name"] for i in response.json()["items"]]
+    assert "linked_dir" not in names, "symlink directories must be excluded from browse results"
+
+
+# ---------------------------------------------------------------------------
+# POST /datastores/{storage_name}/files  — folder authorization
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_register_external_file_folder_not_found(
+    fastapi_async_test_client, mocker, tmp_path
+):
+    """Returns 404 when the target folder does not exist."""
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    storage = _make_storage(mount_point=str(mount))
+    _patch_register_deps(mocker, storage, folder=None)
+
+    response = await fastapi_async_test_client.post(
+        "/datastores/test_store/files",
+        json={"folder_id": 999, "relative_path": "image.dd"},
+    )
+    assert response.status_code == 404
+    assert "folder" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_register_external_file_calls_access_check(
+    fastapi_async_test_client, mocker, tmp_path, authz, file_response
+):
+    """check_user_access is called with EDITOR/OWNER roles when folder exists.
+
+    The autouse ``authz`` fixture already mocks datastores.sql.crud.authz.check_user_access
+    and returns True; here we just assert it was called with the correct roles.
+    """
+    import uuid as uuid_module
+    from datastores.sql.models.folder import Folder
+    from datastores.sql.models.role import Role
+
+    mount = tmp_path / "cases"
+    mount.mkdir()
+    real_file = mount / "image.dd"
+    real_file.write_bytes(b"\x00" * 16)
+    storage = _make_storage(mount_point=str(mount))
+
+    mock_folder = Folder(
+        id=1,
+        display_name="test",
+        uuid=uuid_module.uuid4(),
+        user_id=1,
+    )
+
+    mocker.patch(
+        "api.v1.external_storages.get_external_storage_from_db",
+        return_value=storage,
+    )
+    mocker.patch("api.v1.external_storages.get_folder_from_db", return_value=mock_folder)
+    mocker.patch(
+        "api.v1.external_storages.register_external_file_in_db",
+        return_value=file_response,
+    )
+
+    await fastapi_async_test_client.post(
+        "/datastores/test_store/files",
+        json={"folder_id": 1, "relative_path": "image.dd"},
+    )
+
+    authz.assert_called_once()
+    call_args = authz.call_args
+    roles_arg = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("allowed_roles")
+    assert Role.EDITOR in roles_arg
+    assert Role.OWNER in roles_arg
+
+
+# ---------------------------------------------------------------------------
+# Issue 3 — UniqueConstraint present in File ORM model
+# ---------------------------------------------------------------------------
+
+def test_file_model_has_unique_constraint_for_external_registration():
+    """The File ORM model must declare the uq_file_folder_external constraint so
+    that Alembic autogenerate does not detect it as schema drift."""
+    from sqlalchemy import UniqueConstraint
+    from datastores.sql.models.file import File
+
+    constraint_names = {
+        c.name
+        for c in File.__table_args__
+        if isinstance(c, UniqueConstraint)
+    }
+    assert "uq_file_folder_external" in constraint_names, (
+        "File model is missing __table_args__ UniqueConstraint 'uq_file_folder_external'. "
+        "Add it to keep the ORM in sync with the migration."
+    )

--- a/src/tests/api/v1/external_storages_test.py
+++ b/src/tests/api/v1/external_storages_test.py
@@ -168,18 +168,6 @@ def test_delete_external_storage_success(fastapi_test_client, mocker):
     assert response.status_code == 204
 
 
-def test_delete_external_storage_conflict(fastapi_test_client, mocker):
-    mocker.patch(
-        "api.v1.external_storages.get_external_storage_from_db",
-        return_value=_make_storage(),
-    )
-    mocker.patch(
-        "api.v1.external_storages.delete_external_storage_from_db", return_value=False
-    )
-    response = fastapi_test_client.delete("/datastores/test_store")
-    assert response.status_code == 409
-
-
 def test_delete_external_storage_not_found(fastapi_test_client, mocker):
     mocker.patch(
         "api.v1.external_storages.get_external_storage_from_db", return_value=None

--- a/src/tests/api/v1/folders_test.py
+++ b/src/tests/api/v1/folders_test.py
@@ -288,13 +288,14 @@ def test_delete_user_role(fastapi_test_client, mocker, db):
     mock_delete_user_role_from_db.assert_called_once_with(db, role_id)
 
 
-def test_get_folder_files(fastapi_test_client, mocker, file_response_compact_list):
+def test_get_folder_files(fastapi_test_client, mocker, folder_db_model, file_response_compact_list):
     """Test getting files for a folder."""
     folder_id = 1
     mock_files = [
         file_response_compact_list.model_dump(mode="json"),
         file_response_compact_list.model_dump(mode="json"),
     ]
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=folder_db_model)
     mock_get_files_from_db = mocker.patch("api.v1.folders.get_files_from_db")
     mock_get_files_from_db.return_value = mock_files
 
@@ -319,6 +320,8 @@ def test_get_folder_success(fastapi_test_client, mocker):
     mock_folder.user_roles = []
     mock_folder.group_roles = []
     mock_folder.storage_provider = "local"
+    mock_folder.external_storage_name = None
+    mock_folder.external_base_path = None
 
     mock_user = mocker.MagicMock()
     mock_user.display_name = "Test User"
@@ -852,3 +855,136 @@ async def test_get_adk_sse_session_success(mocker):
 
     assert len(results) > 0
     assert "running" in results[0]
+
+
+# ---------------------------------------------------------------------------
+# External mount tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_folder_files_with_mount_triggers_sync(
+    fastapi_test_client, mocker, folder_db_model, file_response_compact_list
+):
+    """When folder has external_storage_name, sync is triggered before listing files."""
+    folder_db_model.external_storage_name = "my_storage"
+
+    mock_files = [file_response_compact_list.model_dump(mode="json")]
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=folder_db_model)
+    mock_sync = mocker.patch("api.v1.folders.sync_external_mount_files_in_db")
+    mocker.patch("api.v1.folders.get_files_from_db", return_value=mock_files)
+
+    response = fastapi_test_client.get("/folders/1/files/")
+    assert response.status_code == 200
+    mock_sync.assert_called_once()
+
+
+def test_get_folder_files_without_mount_skips_sync(
+    fastapi_test_client, mocker, folder_db_model, file_response_compact_list
+):
+    """When folder has no external mount, sync is not called."""
+    folder_db_model.external_storage_name = None
+
+    mock_files = [file_response_compact_list.model_dump(mode="json")]
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=folder_db_model)
+    mock_sync = mocker.patch("api.v1.folders.sync_external_mount_files_in_db")
+    mocker.patch("api.v1.folders.get_files_from_db", return_value=mock_files)
+
+    response = fastapi_test_client.get("/folders/1/files/")
+    assert response.status_code == 200
+    mock_sync.assert_not_called()
+
+
+def test_get_folder_files_sync_failure_returns_200(
+    fastapi_test_client, mocker, folder_db_model, file_response_compact_list
+):
+    """A sync ValueError is soft-failed — existing files are still returned."""
+    folder_db_model.external_storage_name = "broken_storage"
+
+    mock_files = [file_response_compact_list.model_dump(mode="json")]
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=folder_db_model)
+    mocker.patch(
+        "api.v1.folders.sync_external_mount_files_in_db",
+        side_effect=ValueError("mount not available"),
+    )
+    mocker.patch("api.v1.folders.get_files_from_db", return_value=mock_files)
+
+    response = fastapi_test_client.get("/folders/1/files/")
+    assert response.status_code == 200
+    assert response.json() == mock_files
+
+
+@pytest.mark.asyncio
+async def test_update_folder_sets_external_mount(
+    fastapi_async_test_client, mocker, folder_db_model, folder_response
+):
+    """PATCH with a valid external mount updates the folder."""
+    mock_storage = mocker.MagicMock()
+    mock_storage.mount_point = "/mnt/cases"
+
+    mocker.patch("api.v1.folders.get_external_storage_from_db", return_value=mock_storage)
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=folder_db_model)
+    mock_update = mocker.patch("api.v1.folders.update_folder_in_db", return_value=folder_response)
+
+    request = {"external_storage_name": "my_storage"}
+    response = await fastapi_async_test_client.patch("/folders/1", json=request)
+    assert response.status_code == 200
+    mock_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_folder_clears_external_mount(
+    fastapi_async_test_client, mocker, folder_db_model, folder_response
+):
+    """PATCH with explicit null fields clears the external mount."""
+    mocker.patch("api.v1.folders.get_folder_from_db", return_value=folder_db_model)
+    mock_update = mocker.patch("api.v1.folders.update_folder_in_db", return_value=folder_response)
+
+    request = {"external_storage_name": None, "external_base_path": None}
+    response = await fastapi_async_test_client.patch("/folders/1", json=request)
+    assert response.status_code == 200
+
+    # Verify that the FolderUpdateRequest passed to update_folder_in_db has None for both
+    # mount fields and that those keys are in model_fields_set (explicitly sent in request).
+    folder_arg = mock_update.call_args[0][2]  # third positional arg is the FolderUpdateRequest
+    assert folder_arg.external_storage_name is None
+    assert folder_arg.external_base_path is None
+    assert "external_storage_name" in folder_arg.model_fields_set
+    assert "external_base_path" in folder_arg.model_fields_set
+
+
+@pytest.mark.asyncio
+async def test_update_folder_invalid_storage_name_returns_400(
+    fastapi_async_test_client, mocker
+):
+    """PATCH with a non-existent storage name returns 400."""
+    mocker.patch("api.v1.folders.get_external_storage_from_db", return_value=None)
+
+    request = {"external_storage_name": "nonexistent_storage"}
+    response = await fastapi_async_test_client.patch("/folders/1", json=request)
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_folder_null_clears_mount_uses_model_fields_set(
+    fastapi_async_test_client, mocker, folder_response
+):
+    """Regression: explicit null in request must reach update_folder_in_db via model_fields_set.
+
+    Before the Bug 1 fix, the endpoint merged the update into a FolderCreate model and
+    passed that merged model to the CRUD. The CRUD's ``if value is not None`` guard then
+    silently dropped the null, leaving the old value in the DB.  Now the CRUD iterates
+    ``model_fields_set`` so explicit nulls are always written.
+    """
+    mock_update = mocker.patch("api.v1.folders.update_folder_in_db", return_value=folder_response)
+
+    # Send explicit nulls for both mount fields
+    request = {"external_storage_name": None, "external_base_path": None}
+    response = await fastapi_async_test_client.patch("/folders/1", json=request)
+    assert response.status_code == 200
+
+    folder_arg = mock_update.call_args[0][2]  # FolderUpdateRequest
+    # Both fields must be in model_fields_set so the CRUD will write None to the DB.
+    assert "external_storage_name" in folder_arg.model_fields_set
+    assert "external_base_path" in folder_arg.model_fields_set
+    assert folder_arg.external_storage_name is None
+    assert folder_arg.external_base_path is None

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -34,6 +34,7 @@ from sqlalchemy.orm import Session
 
 from api.v1 import schemas
 from api.v1.configs import router as configs_router
+from api.v1.external_storages import router as external_storages_router
 from api.v1.files import router as files_router
 from api.v1.folders import router as folders_router
 from api.v1.groups import router as groups_router
@@ -687,6 +688,7 @@ def setup_test_app(user_response, db) -> FastAPI:
     # Set up all the necessary FastAPI routes.
     app.include_router(taskqueue_router, prefix="/taskqueue", tags=["taskqueue"], dependencies=[])
     app.include_router(configs_router, prefix="/configs", tags=["configs"], dependencies=[])
+    app.include_router(external_storages_router, prefix="/datastores", tags=["datastores"], dependencies=[])
     app.include_router(files_router, prefix="/files", tags=["files"], dependencies=[])
     app.include_router(folders_router, prefix="/folders", tags=["folders"], dependencies=[])
     app.include_router(groups_router, prefix="/groups", tags=["groups"], dependencies=[])

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -573,6 +573,8 @@ def folder_db_model(user_db_model) -> Folder:
         "deleted_at": None,
         "id": 1,
         "is_deleted": False,
+        "external_storage_name": None,
+        "external_base_path": None,
     }
 
     mock_folder_response = Folder(**folder_data)

--- a/src/tests/test_delete_external_storage.py
+++ b/src/tests/test_delete_external_storage.py
@@ -1,0 +1,346 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for delete_external_storage_from_db cascade behaviour.
+
+Uses an in-memory SQLite database so the full FK-safe deletion sequence can
+be verified end-to-end, including:
+  - File records are deleted from the DB
+  - Folders are unmounted (external_storage_name set to NULL)
+  - UserRole rows for affected files are removed
+  - Physical files on disk are NOT removed
+  - The ExternalStorage record itself is removed
+"""
+
+import uuid as uuid_module
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from datastores.sql.crud.external_storage import delete_external_storage_from_db
+from datastores.sql.database import BaseModel
+from datastores.sql.models.external_storage import ExternalStorage
+from datastores.sql.models.file import File
+from datastores.sql.models.folder import Folder
+from datastores.sql.models.role import Role
+from datastores.sql.models.user import User, UserRole
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sqlite_session():
+    """Real SQLite in-memory session with all tables created."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autocommit=False, autoflush=True)
+    session = Session()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_db(sqlite_session, tmp_path):
+    """Seed the DB with a user, storage, two folders, two files, and their UserRoles.
+
+    Folder layout:
+      folder_a  — mounted to test_store / base_a (has file_a)
+      folder_b  — mounted to test_store / (no base_path) (has file_b)
+
+    Physical files are created on disk so we can assert they survive.
+
+    Returns a dict with the created objects and physical paths.
+    """
+    db = sqlite_session
+
+    user = User(
+        username="tester",
+        display_name="Tester",
+        email="t@example.com",
+        password_hash="x",
+        auth_method="local",
+        uuid=uuid_module.uuid4(),
+    )
+    db.add(user)
+    db.flush()
+
+    storage = ExternalStorage(
+        name="test_store",
+        mount_point=str(tmp_path),
+        description=None,
+    )
+    db.add(storage)
+    db.flush()
+
+    # Folder A — mounted with a base path
+    base_a = tmp_path / "base_a"
+    base_a.mkdir()
+    folder_a = Folder(
+        display_name="folder_a",
+        uuid=uuid_module.uuid4(),
+        user_id=user.id,
+        external_storage_name="test_store",
+        external_base_path="base_a",
+    )
+    db.add(folder_a)
+    db.flush()
+
+    physical_a = base_a / "image_a.dd"
+    physical_a.write_bytes(b"\x00" * 16)
+
+    file_a = File(
+        display_name="image_a.dd",
+        uuid=uuid_module.uuid4(),
+        filename="image_a.dd",
+        filesize=16,
+        extension="dd",
+        data_type="file:generic",
+        user_id=user.id,
+        folder_id=folder_a.id,
+        external_storage_name="test_store",
+        external_relative_path="base_a/image_a.dd",
+    )
+    db.add(file_a)
+    db.flush()
+
+    role_a = UserRole(user_id=user.id, file_id=file_a.id, role=Role.OWNER)
+    db.add(role_a)
+
+    # Folder B — mounted at root of storage
+    folder_b = Folder(
+        display_name="folder_b",
+        uuid=uuid_module.uuid4(),
+        user_id=user.id,
+        external_storage_name="test_store",
+        external_base_path=None,
+    )
+    db.add(folder_b)
+    db.flush()
+
+    physical_b = tmp_path / "image_b.dd"
+    physical_b.write_bytes(b"\x00" * 32)
+
+    file_b = File(
+        display_name="image_b.dd",
+        uuid=uuid_module.uuid4(),
+        filename="image_b.dd",
+        filesize=32,
+        extension="dd",
+        data_type="file:generic",
+        user_id=user.id,
+        folder_id=folder_b.id,
+        external_storage_name="test_store",
+        external_relative_path="image_b.dd",
+    )
+    db.add(file_b)
+    db.flush()
+
+    role_b = UserRole(user_id=user.id, file_id=file_b.id, role=Role.OWNER)
+    db.add(role_b)
+
+    db.commit()
+
+    return {
+        "db": db,
+        "user": user,
+        "storage": storage,
+        "folder_a": folder_a,
+        "folder_b": folder_b,
+        "file_a": file_a,
+        "file_b": file_b,
+        "role_a": role_a,
+        "role_b": role_b,
+        "physical_a": physical_a,
+        "physical_b": physical_b,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_delete_storage_removes_storage_record(seeded_db):
+    """The ExternalStorage record is deleted from the DB."""
+    db = seeded_db["db"]
+    storage = seeded_db["storage"]
+
+    assert db.query(ExternalStorage).filter_by(name="test_store").count() == 1
+
+    delete_external_storage_from_db(db, storage)
+
+    assert db.query(ExternalStorage).filter_by(name="test_store").count() == 0
+
+
+def test_delete_storage_removes_file_records(seeded_db):
+    """All File DB records referencing the storage are deleted."""
+    db = seeded_db["db"]
+    storage = seeded_db["storage"]
+
+    assert db.query(File).filter_by(external_storage_name="test_store").count() == 2
+
+    delete_external_storage_from_db(db, storage)
+
+    assert db.query(File).filter_by(external_storage_name="test_store").count() == 0
+
+
+def test_delete_storage_removes_userrole_records(seeded_db):
+    """UserRole rows for the deleted files are removed."""
+    db = seeded_db["db"]
+    storage = seeded_db["storage"]
+    file_a_id = seeded_db["file_a"].id
+    file_b_id = seeded_db["file_b"].id
+
+    assert db.query(UserRole).filter(UserRole.file_id.in_([file_a_id, file_b_id])).count() == 2
+
+    delete_external_storage_from_db(db, storage)
+
+    assert db.query(UserRole).filter(UserRole.file_id.in_([file_a_id, file_b_id])).count() == 0
+
+
+def test_delete_storage_unmounts_folders(seeded_db):
+    """All folders mounted to the storage are unmounted (external_storage_name set to NULL)."""
+    db = seeded_db["db"]
+    storage = seeded_db["storage"]
+    folder_a_id = seeded_db["folder_a"].id
+    folder_b_id = seeded_db["folder_b"].id
+
+    delete_external_storage_from_db(db, storage)
+
+    db.expire_all()
+    folder_a = db.get(Folder, folder_a_id)
+    folder_b = db.get(Folder, folder_b_id)
+    assert folder_a.external_storage_name is None
+    assert folder_a.external_base_path is None
+    assert folder_b.external_storage_name is None
+    assert folder_b.external_base_path is None
+
+
+def test_delete_storage_does_not_delete_physical_files(seeded_db):
+    """Physical files on disk are NOT removed when the storage is deleted."""
+    db = seeded_db["db"]
+    storage = seeded_db["storage"]
+    physical_a = seeded_db["physical_a"]
+    physical_b = seeded_db["physical_b"]
+
+    assert physical_a.exists(), "precondition: file_a must exist"
+    assert physical_b.exists(), "precondition: file_b must exist"
+
+    delete_external_storage_from_db(db, storage)
+
+    assert physical_a.exists(), "physical_a must survive storage deletion"
+    assert physical_b.exists(), "physical_b must survive storage deletion"
+
+
+def test_delete_storage_with_no_references_succeeds(sqlite_session):
+    """Deleting a storage that has no file/folder references works without error."""
+    db = sqlite_session
+
+    storage = ExternalStorage(
+        name="empty_store",
+        mount_point="/mnt/empty",
+        description=None,
+    )
+    db.add(storage)
+    db.commit()
+
+    result = delete_external_storage_from_db(db, storage)
+
+    assert result is True
+    assert db.query(ExternalStorage).filter_by(name="empty_store").count() == 0
+
+
+def test_delete_storage_returns_true(seeded_db):
+    """delete_external_storage_from_db always returns True."""
+    db = seeded_db["db"]
+    storage = seeded_db["storage"]
+
+    result = delete_external_storage_from_db(db, storage)
+
+    assert result is True
+
+
+def test_delete_storage_removes_soft_deleted_file_records(sqlite_session, tmp_path):
+    """Files with is_deleted=True are also removed (Core SQL bypasses soft-delete filter)."""
+    db = sqlite_session
+
+    user = User(
+        username="tester2",
+        display_name="Tester2",
+        email="t2@example.com",
+        password_hash="x",
+        auth_method="local",
+        uuid=uuid_module.uuid4(),
+    )
+    db.add(user)
+    db.flush()
+
+    storage = ExternalStorage(
+        name="soft_store",
+        mount_point=str(tmp_path),
+        description=None,
+    )
+    db.add(storage)
+    db.flush()
+
+    folder = Folder(
+        display_name="folder",
+        uuid=uuid_module.uuid4(),
+        user_id=user.id,
+        external_storage_name="soft_store",
+        external_base_path=None,
+    )
+    db.add(folder)
+    db.flush()
+
+    # Create a file that is already soft-deleted
+    soft_file = File(
+        display_name="ghost.dd",
+        uuid=uuid_module.uuid4(),
+        filename="ghost.dd",
+        filesize=8,
+        extension="dd",
+        data_type="file:generic",
+        user_id=user.id,
+        folder_id=folder.id,
+        external_storage_name="soft_store",
+        external_relative_path="ghost.dd",
+        is_deleted=True,
+    )
+    db.add(soft_file)
+    db.commit()
+
+    # Precondition: the file exists in the DB (ORM query won't see it due to
+    # the soft-delete filter, but the raw count should show 1)
+    from sqlalchemy import text
+    raw_count = db.execute(
+        text("SELECT COUNT(*) FROM file WHERE external_storage_name = 'soft_store'")
+    ).scalar()
+    assert raw_count == 1
+
+    delete_external_storage_from_db(db, storage)
+
+    # The file must be gone from the DB entirely
+    raw_count_after = db.execute(
+        text("SELECT COUNT(*) FROM file WHERE external_storage_name = 'soft_store'")
+    ).scalar()
+    assert raw_count_after == 0

--- a/src/tests/test_external_storage_path.py
+++ b/src/tests/test_external_storage_path.py
@@ -1,0 +1,154 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for File.path() with external storage and path traversal validation."""
+
+import uuid
+
+import pytest
+
+from datastores.sql.models.external_storage import ExternalStorage
+from datastores.sql.models.file import File
+
+
+def _make_external_storage(mount_point: str) -> ExternalStorage:
+    return ExternalStorage(
+        id=1,
+        name="test_store",
+        mount_point=mount_point,
+        description=None,
+    )
+
+
+def _make_file(
+    external_storage_name: str = None,
+    external_relative_path: str = None,
+    external_storage: ExternalStorage = None,
+    storage_provider: str = None,
+    storage_key: str = None,
+    folder=None,
+    extension: str = "dd",
+) -> File:
+    file_uuid = uuid.UUID("3fa85f64-5717-4562-b3fc-2c963f66afa6")
+    return File(
+        id=1,
+        uuid=file_uuid,
+        display_name="test.dd",
+        filename="test.dd",
+        filesize=1024,
+        extension=extension,
+        data_type="file:generic",
+        user_id=1,
+        folder_id=1,
+        folder=folder,
+        external_storage_name=external_storage_name,
+        external_relative_path=external_relative_path,
+        external_storage=external_storage,
+        storage_provider=storage_provider,
+        storage_key=storage_key,
+    )
+
+
+class TestExternalStoragePath:
+    def test_path_returns_mount_plus_relative(self, tmp_path):
+        mount = str(tmp_path / "cases")
+        storage = _make_external_storage(mount)
+        f = _make_file(
+            external_storage_name="test_store",
+            external_relative_path="case/123/image.dd",
+            external_storage=storage,
+        )
+        expected = f"{mount}/case/123/image.dd"
+        assert f.path == expected
+
+    def test_path_strips_leading_slash_from_relative(self, tmp_path):
+        mount = str(tmp_path / "cases")
+        storage = _make_external_storage(mount)
+        f = _make_file(
+            external_storage_name="test_store",
+            external_relative_path="/case/123/image.dd",
+            external_storage=storage,
+        )
+        result = f.path
+        assert not result.startswith(mount + "//")
+        assert result.endswith("case/123/image.dd")
+
+    def test_path_traversal_raises_value_error(self, tmp_path):
+        mount = str(tmp_path / "cases")
+        storage = _make_external_storage(mount)
+        f = _make_file(
+            external_storage_name="test_store",
+            external_relative_path="case/../../etc/passwd",
+            external_storage=storage,
+        )
+        with pytest.raises(ValueError, match="Path traversal"):
+            _ = f.path
+
+    def test_path_traversal_dotdot_at_start(self, tmp_path):
+        mount = str(tmp_path / "cases")
+        storage = _make_external_storage(mount)
+        f = _make_file(
+            external_storage_name="test_store",
+            external_relative_path="../secret",
+            external_storage=storage,
+        )
+        with pytest.raises(ValueError, match="Path traversal"):
+            _ = f.path
+
+    def test_path_traversal_windows_style(self, tmp_path):
+        mount = str(tmp_path / "cases")
+        storage = _make_external_storage(mount)
+        f = _make_file(
+            external_storage_name="test_store",
+            external_relative_path="case\\..\\..\\secret",
+            external_storage=storage,
+        )
+        with pytest.raises(ValueError, match="Path traversal"):
+            _ = f.path
+
+    def test_missing_external_storage_object_raises(self, tmp_path):
+        f = _make_file(
+            external_storage_name="missing_store",
+            external_relative_path="case/image.dd",
+            external_storage=None,
+        )
+        with pytest.raises(ValueError, match="not found in database"):
+            _ = f.path
+
+    def test_missing_relative_path_raises(self, tmp_path):
+        mount = str(tmp_path / "cases")
+        storage = _make_external_storage(mount)
+        f = _make_file(
+            external_storage_name="test_store",
+            external_relative_path=None,
+            external_storage=storage,
+        )
+        with pytest.raises(ValueError, match="No relative path"):
+            _ = f.path
+
+
+class TestIsExternal:
+    def test_is_external_true_when_name_set(self, tmp_path):
+        mount = str(tmp_path / "cases")
+        storage = _make_external_storage(mount)
+        f = _make_file(
+            external_storage_name="test_store",
+            external_relative_path="a/b.dd",
+            external_storage=storage,
+        )
+        assert f.is_external is True
+
+    def test_is_external_false_when_name_not_set(self):
+        f = _make_file()
+        assert f.is_external is False

--- a/src/tests/test_sync_external_mount.py
+++ b/src/tests/test_sync_external_mount.py
@@ -1,0 +1,275 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for sync_external_mount_files_in_db (crud/file.py)."""
+
+import os
+import uuid
+
+import pytest
+
+from datastores.sql.crud.file import sync_external_mount_files_in_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_storage(mount_point):
+    """Return a minimal ExternalStorage-like object."""
+
+    class _Storage:
+        name = "test_store"
+
+    _Storage.mount_point = str(mount_point)
+    return _Storage()
+
+
+def _make_folder(storage_name, base_path, folder_id=1):
+    """Return a minimal Folder-like object."""
+
+    class _Folder:
+        id = folder_id
+        external_storage_name = storage_name
+        external_base_path = base_path
+
+    return _Folder()
+
+
+def _make_user():
+    class _User:
+        id = 99
+
+    return _User()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_db(mocker):
+    """A db session whose query returns an empty existing_paths set by default."""
+    db = mocker.MagicMock()
+    # query(...).filter_by(...).all() → []
+    db.query.return_value.filter_by.return_value.all.return_value = []
+    return db
+
+
+@pytest.fixture()
+def mock_register(mocker):
+    # The function is imported lazily inside sync_external_mount_files_in_db, so
+    # patch its definition in the source module rather than the reference in file.py.
+    return mocker.patch(
+        "datastores.sql.crud.external_storage.register_external_file_in_db",
+        return_value=mocker.MagicMock(),
+    )
+
+
+@pytest.fixture()
+def mock_get_storage(mocker):
+    """Patch get_external_storage_from_db in its source module (lazy import)."""
+    return mocker.patch(
+        "datastores.sql.crud.external_storage.get_external_storage_from_db"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — flat directory (top-level files only)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_registers_top_level_files(tmp_path, mock_db, mock_register, mock_get_storage):
+    """Files directly in the base directory are registered."""
+    (tmp_path / "a.bin").write_bytes(b"data")
+    (tmp_path / "b.txt").write_bytes(b"data")
+
+    storage = _make_storage(tmp_path)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", None)
+
+    sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+    assert mock_register.call_count == 2
+    registered = {c.args[2] for c in mock_register.call_args_list}  # relative_path arg
+    assert registered == {"a.bin", "b.txt"}
+
+
+def test_sync_is_idempotent(tmp_path, mock_db, mock_register, mock_get_storage, mocker):
+    """Already-registered paths are not re-registered."""
+    (tmp_path / "exists.bin").write_bytes(b"data")
+
+    storage = _make_storage(tmp_path)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", None)
+
+    # Simulate the file already being in existing_paths
+    row = mocker.MagicMock()
+    row.external_relative_path = "exists.bin"
+    mock_db.query.return_value.filter_by.return_value.all.return_value = [row]
+
+    sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+    mock_register.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests — recursive walk (Bug 2)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_registers_files_in_subdirectory(
+    tmp_path, mock_db, mock_register, mock_get_storage
+):
+    """Files nested inside subdirectories are registered with a relative path
+    that includes the subdirectory prefix."""
+    subdir = tmp_path / "evidence"
+    subdir.mkdir()
+    (subdir / "image.dd").write_bytes(b"data")
+
+    storage = _make_storage(tmp_path)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", None)
+
+    sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+    assert mock_register.call_count == 1
+    relative_path = mock_register.call_args.args[2]
+    assert relative_path == os.path.join("evidence", "image.dd")
+
+
+def test_sync_registers_deeply_nested_files(
+    tmp_path, mock_db, mock_register, mock_get_storage
+):
+    """Files at multiple levels of nesting are all registered."""
+    (tmp_path / "top.bin").write_bytes(b"data")
+    level1 = tmp_path / "l1"
+    level1.mkdir()
+    (level1 / "mid.bin").write_bytes(b"data")
+    level2 = level1 / "l2"
+    level2.mkdir()
+    (level2 / "deep.bin").write_bytes(b"data")
+
+    storage = _make_storage(tmp_path)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", None)
+
+    sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+    assert mock_register.call_count == 3
+    registered = {c.args[2] for c in mock_register.call_args_list}
+    assert registered == {
+        "top.bin",
+        os.path.join("l1", "mid.bin"),
+        os.path.join("l1", "l2", "deep.bin"),
+    }
+
+
+def test_sync_with_external_base_path_registers_nested_files(
+    tmp_path, mock_db, mock_register, mock_get_storage
+):
+    """When external_base_path points to a subdirectory, nested files still get
+    a relative_path relative to mount_point (not to external_base_path)."""
+    base = tmp_path / "cases"
+    base.mkdir()
+    sub = base / "sub"
+    sub.mkdir()
+    (sub / "file.bin").write_bytes(b"data")
+
+    storage = _make_storage(tmp_path)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", "cases")
+
+    sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+    assert mock_register.call_count == 1
+    relative_path = mock_register.call_args.args[2]
+    assert relative_path == os.path.join("cases", "sub", "file.bin")
+
+
+def test_sync_skips_symlinks(tmp_path, mock_db, mock_register, mock_get_storage):
+    """Symbolic links to files are skipped."""
+    real_file = tmp_path / "real.bin"
+    real_file.write_bytes(b"data")
+    link = tmp_path / "link.bin"
+    link.symlink_to(real_file)
+
+    storage = _make_storage(tmp_path)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", None)
+
+    sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+    # Only the real file should be registered, not the symlink
+    assert mock_register.call_count == 1
+    registered = {c.args[2] for c in mock_register.call_args_list}
+    assert "real.bin" in registered
+    assert "link.bin" not in registered
+
+
+def test_sync_does_not_follow_symlinked_directories(
+    tmp_path, mock_db, mock_register, mock_get_storage
+):
+    """Symbolic links to directories are not followed (followlinks=False)."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.bin").write_bytes(b"data")
+
+    inside = tmp_path / "mount"
+    inside.mkdir()
+    link_dir = inside / "linked_dir"
+    link_dir.symlink_to(outside)
+
+    storage = _make_storage(inside)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", None)
+
+    sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+    mock_register.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests — error cases
+# ---------------------------------------------------------------------------
+
+
+def test_sync_raises_if_storage_not_found(mock_db, mock_get_storage):
+    mock_get_storage.return_value = None
+    folder = _make_folder("missing_store", None)
+
+    with pytest.raises(ValueError, match="not found"):
+        sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+
+def test_sync_raises_if_base_path_escapes_mount(tmp_path, mock_db, mock_get_storage):
+    storage = _make_storage(tmp_path / "mount")
+    os.makedirs(storage.mount_point, exist_ok=True)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", "../outside")
+
+    with pytest.raises(ValueError, match="escapes mount point"):
+        sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+
+def test_sync_raises_if_resolved_path_not_a_directory(tmp_path, mock_db, mock_get_storage):
+    (tmp_path / "afile").write_bytes(b"data")
+    storage = _make_storage(tmp_path)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", "afile")  # points to a file, not a directory
+
+    with pytest.raises(ValueError, match="not a directory"):
+        sync_external_mount_files_in_db(mock_db, folder, _make_user())

--- a/src/tests/test_sync_external_mount.py
+++ b/src/tests/test_sync_external_mount.py
@@ -15,11 +15,19 @@
 """Unit tests for sync_external_mount_files_in_db (crud/file.py)."""
 
 import os
-import uuid
+import uuid as uuid_module
 
 import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from datastores.sql.crud.file import sync_external_mount_files_in_db
+from datastores.sql.database import BaseModel
+from datastores.sql.models.external_storage import ExternalStorage
+from datastores.sql.models.file import File
+from datastores.sql.models.folder import Folder
+from datastores.sql.models.user import User
 
 
 # ---------------------------------------------------------------------------
@@ -62,10 +70,14 @@ def _make_user():
 
 @pytest.fixture()
 def mock_db(mocker):
-    """A db session whose query returns an empty existing_paths set by default."""
+    """A db session that returns an empty existing_paths set by default.
+
+    existing_paths is collected via db.execute(...).fetchall() (Core SQL) so
+    that soft-deleted records are included in the duplicate check.
+    """
     db = mocker.MagicMock()
-    # query(...).filter_by(...).all() → []
-    db.query.return_value.filter_by.return_value.all.return_value = []
+    # execute(...).fetchall() → [] (no previously registered paths)
+    db.execute.return_value.fetchall.return_value = []
     return db
 
 
@@ -108,18 +120,20 @@ def test_sync_registers_top_level_files(tmp_path, mock_db, mock_register, mock_g
     assert registered == {"a.bin", "b.txt"}
 
 
-def test_sync_is_idempotent(tmp_path, mock_db, mock_register, mock_get_storage, mocker):
-    """Already-registered paths are not re-registered."""
+def test_sync_is_idempotent(tmp_path, mock_db, mock_register, mock_get_storage):
+    """Already-registered paths (including soft-deleted ones) are not re-registered.
+
+    existing_paths is now populated via db.execute(...).fetchall() (Core SQL) so
+    that soft-deleted records are included.  The mock must reflect this path.
+    """
     (tmp_path / "exists.bin").write_bytes(b"data")
 
     storage = _make_storage(tmp_path)
     mock_get_storage.return_value = storage
     folder = _make_folder("test_store", None)
 
-    # Simulate the file already being in existing_paths
-    row = mocker.MagicMock()
-    row.external_relative_path = "exists.bin"
-    mock_db.query.return_value.filter_by.return_value.all.return_value = [row]
+    # Simulate the path already being registered (Core SQL returns a list of 1-tuples)
+    mock_db.execute.return_value.fetchall.return_value = [("exists.bin",)]
 
     sync_external_mount_files_in_db(mock_db, folder, _make_user())
 
@@ -200,6 +214,42 @@ def test_sync_with_external_base_path_registers_nested_files(
     assert relative_path == os.path.join("cases", "sub", "file.bin")
 
 
+def test_sync_external_base_path_excludes_files_outside_base(
+    tmp_path, mock_db, mock_register, mock_get_storage
+):
+    """Only files under external_base_path are registered; files at the mount root
+    or in sibling directories must be ignored."""
+    # Files outside the base path (should NOT be registered)
+    (tmp_path / "root_file.dd").write_bytes(b"data")
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    (sibling / "sibling_file.dd").write_bytes(b"data")
+
+    # Files inside the base path (should be registered)
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    (evidence / "inside.dd").write_bytes(b"data")
+    sub = evidence / "sub"
+    sub.mkdir()
+    (sub / "nested.dd").write_bytes(b"data")
+
+    storage = _make_storage(tmp_path)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", "evidence")
+
+    sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+    assert mock_register.call_count == 2
+    registered = {c.args[2] for c in mock_register.call_args_list}
+    assert registered == {
+        os.path.join("evidence", "inside.dd"),
+        os.path.join("evidence", "sub", "nested.dd"),
+    }
+    # Confirm files outside the base path were never passed to register
+    assert "root_file.dd" not in registered
+    assert os.path.join("sibling", "sibling_file.dd") not in registered
+
+
 def test_sync_skips_symlinks(tmp_path, mock_db, mock_register, mock_get_storage):
     """Symbolic links to files are skipped."""
     real_file = tmp_path / "real.bin"
@@ -255,11 +305,29 @@ def test_sync_raises_if_storage_not_found(mock_db, mock_get_storage):
         sync_external_mount_files_in_db(mock_db, folder, _make_user())
 
 
-def test_sync_raises_if_base_path_escapes_mount(tmp_path, mock_db, mock_get_storage):
+def test_sync_raises_if_base_path_contains_dotdot(tmp_path, mock_db, mock_get_storage):
+    """external_base_path with '..' components is rejected before realpath resolution."""
     storage = _make_storage(tmp_path / "mount")
     os.makedirs(storage.mount_point, exist_ok=True)
     mock_get_storage.return_value = storage
     folder = _make_folder("test_store", "../outside")
+
+    with pytest.raises(ValueError, match="traversal"):
+        sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+
+def test_sync_raises_if_base_path_escapes_mount(tmp_path, mock_db, mock_get_storage):
+    """Paths that escape the mount point via symlinks are rejected after realpath."""
+    mount = tmp_path / "mount"
+    mount.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    # Symlink inside mount that points outside — no '..' in the name, so the
+    # explicit check passes, but realpath resolves it outside the mount.
+    (mount / "escape").symlink_to(outside)
+    storage = _make_storage(mount)
+    mock_get_storage.return_value = storage
+    folder = _make_folder("test_store", "escape")
 
     with pytest.raises(ValueError, match="escapes mount point"):
         sync_external_mount_files_in_db(mock_db, folder, _make_user())
@@ -273,3 +341,96 @@ def test_sync_raises_if_resolved_path_not_a_directory(tmp_path, mock_db, mock_ge
 
     with pytest.raises(ValueError, match="not a directory"):
         sync_external_mount_files_in_db(mock_db, folder, _make_user())
+
+
+# ---------------------------------------------------------------------------
+# Integration test — soft-deleted duplicate prevention
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sqlite_session():
+    """In-memory SQLite session with all tables created."""
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autocommit=False, autoflush=True)
+    session = Session()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+def test_sync_does_not_create_duplicates_for_soft_deleted_paths(
+    sqlite_session, tmp_path
+):
+    """Calling sync twice when the first record is soft-deleted must not insert
+    a second record for the same path.
+
+    The ORM query path adds WHERE is_deleted = FALSE, so soft-deleted records
+    are invisible and the path would be re-registered on every sync.  The fix
+    uses Core SQL which bypasses the filter and includes soft-deleted rows in
+    the existing_paths set.
+    """
+    db = sqlite_session
+
+    user = User(
+        username="tester",
+        display_name="Tester",
+        email="t@example.com",
+        password_hash="x",
+        auth_method="local",
+        uuid=uuid_module.uuid4(),
+    )
+    db.add(user)
+    db.flush()
+
+    storage = ExternalStorage(
+        name="test_store",
+        mount_point=str(tmp_path),
+        description=None,
+    )
+    db.add(storage)
+    db.flush()
+
+    folder = Folder(
+        display_name="evidence_folder",
+        uuid=uuid_module.uuid4(),
+        user_id=user.id,
+        external_storage_name="test_store",
+        external_base_path=None,
+    )
+    db.add(folder)
+    db.commit()
+
+    # Create the physical file
+    (tmp_path / "image.dd").write_bytes(b"\x00" * 16)
+
+    # First sync — registers the file normally
+    sync_external_mount_files_in_db(db, folder, user)
+
+    count_after_first = db.execute(
+        sa.text("SELECT COUNT(*) FROM file WHERE folder_id = :fid AND external_storage_name = 'test_store'"),
+        {"fid": folder.id},
+    ).scalar()
+    assert count_after_first == 1
+
+    # Soft-delete the registered record (simulates the user soft-deleting the file)
+    db.execute(
+        sa.text("UPDATE file SET is_deleted = 1 WHERE folder_id = :fid AND external_storage_name = 'test_store'"),
+        {"fid": folder.id},
+    )
+    db.commit()
+
+    # Second sync — must NOT insert a new record for the same path
+    sync_external_mount_files_in_db(db, folder, user)
+
+    count_after_second = db.execute(
+        sa.text("SELECT COUNT(*) FROM file WHERE folder_id = :fid AND external_storage_name = 'test_store'"),
+        {"fid": folder.id},
+    ).scalar()
+    assert count_after_second == 1, (
+        f"Expected 1 total record (including soft-deleted), got {count_after_second}. "
+        "sync must not re-register paths that are already present in a soft-deleted state."
+    )

--- a/src/tests/test_unmount_external_folder.py
+++ b/src/tests/test_unmount_external_folder.py
@@ -1,0 +1,212 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for external-mount cleanup in update_folder_in_db.
+
+Uses an in-memory SQLite database so the full FK-safe deletion sequence can
+be verified end-to-end, including the assertion that physical files survive.
+"""
+
+import uuid as uuid_module
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.v1.schemas import FolderUpdateRequest
+from datastores.sql.crud.folder import update_folder_in_db
+from datastores.sql.database import BaseModel
+from datastores.sql.models.external_storage import ExternalStorage
+from datastores.sql.models.file import File
+from datastores.sql.models.folder import Folder
+from datastores.sql.models.role import Role
+from datastores.sql.models.user import User, UserRole
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sqlite_session():
+    """Real SQLite in-memory session with all tables created."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autocommit=False, autoflush=True)
+    session = Session()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_db(sqlite_session, tmp_path):
+    """Seed the DB with a user, storage, folder, one external file, and its UserRole.
+
+    Also creates the physical file on disk so we can assert it is not deleted.
+
+    Returns a dict with the created objects and the physical path.
+    """
+    db = sqlite_session
+
+    # User
+    user = User(
+        username="tester",
+        display_name="Tester",
+        email="t@example.com",
+        password_hash="x",
+        auth_method="local",
+        uuid=uuid_module.uuid4(),
+    )
+    db.add(user)
+    db.flush()  # Get user.id without committing
+
+    # ExternalStorage
+    storage = ExternalStorage(
+        name="test_store",
+        mount_point=str(tmp_path),
+        description=None,
+    )
+    db.add(storage)
+    db.flush()
+
+    # Folder mounted to that storage
+    folder = Folder(
+        display_name="evidence_folder",
+        uuid=uuid_module.uuid4(),
+        user_id=user.id,
+        external_storage_name="test_store",
+        external_base_path=None,
+    )
+    db.add(folder)
+    db.flush()
+
+    # Physical file on disk
+    physical_file = tmp_path / "image.dd"
+    physical_file.write_bytes(b"\x00" * 16)
+
+    # Lazily-registered File record (mirrors what register_external_file_in_db creates)
+    file_record = File(
+        display_name="image.dd",
+        uuid=uuid_module.uuid4(),
+        filename="image.dd",
+        filesize=16,
+        extension="dd",
+        data_type="file:generic",
+        user_id=user.id,
+        folder_id=folder.id,
+        external_storage_name="test_store",
+        external_relative_path="image.dd",
+    )
+    db.add(file_record)
+    db.flush()
+
+    # UserRole created alongside the file by register_external_file_in_db
+    role = UserRole(user_id=user.id, file_id=file_record.id, role=Role.OWNER)
+    db.add(role)
+    db.commit()
+
+    return {
+        "db": db,
+        "user": user,
+        "folder": folder,
+        "file_record": file_record,
+        "role": role,
+        "physical_file": physical_file,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_unmount_deletes_external_file_records(seeded_db):
+    """When a folder is unmounted, its external File DB records are deleted."""
+    db = seeded_db["db"]
+    folder = seeded_db["folder"]
+
+    # Precondition: one File record exists
+    assert db.query(File).filter_by(folder_id=folder.id).count() == 1
+
+    update_folder_in_db(db, folder.id, FolderUpdateRequest(external_storage_name=None))
+
+    # File record must be gone from the DB
+    assert db.query(File).filter_by(folder_id=folder.id).count() == 0
+
+
+def test_unmount_deletes_associated_userrole(seeded_db):
+    """UserRole records linked to the deleted files are removed."""
+    db = seeded_db["db"]
+    folder = seeded_db["folder"]
+    file_id = seeded_db["file_record"].id
+
+    # Precondition: one UserRole for this file
+    assert db.query(UserRole).filter_by(file_id=file_id).count() == 1
+
+    update_folder_in_db(db, folder.id, FolderUpdateRequest(external_storage_name=None))
+
+    assert db.query(UserRole).filter_by(file_id=file_id).count() == 0
+
+
+def test_unmount_does_not_delete_physical_file(seeded_db):
+    """Physical files on disk are NOT removed when DB records are cleaned up."""
+    db = seeded_db["db"]
+    folder = seeded_db["folder"]
+    physical_file = seeded_db["physical_file"]
+
+    assert physical_file.exists(), "precondition: file must exist before unmount"
+
+    update_folder_in_db(db, folder.id, FolderUpdateRequest(external_storage_name=None))
+
+    assert physical_file.exists(), "physical file must survive DB record deletion"
+
+
+def test_unmount_clears_external_storage_name_on_folder(seeded_db):
+    """The folder's external_storage_name is set to None after unmounting."""
+    db = seeded_db["db"]
+    folder = seeded_db["folder"]
+
+    updated = update_folder_in_db(
+        db, folder.id, FolderUpdateRequest(external_storage_name=None)
+    )
+
+    assert updated.external_storage_name is None
+
+
+def test_no_deletion_when_not_unmounting(seeded_db):
+    """Updating display_name only must not delete any File records."""
+    db = seeded_db["db"]
+    folder = seeded_db["folder"]
+
+    update_folder_in_db(db, folder.id, FolderUpdateRequest(display_name="renamed"))
+
+    # File record must still be present
+    assert db.query(File).filter_by(folder_id=folder.id).count() == 1
+
+
+def test_unmount_is_idempotent(seeded_db):
+    """Calling unmount twice must not raise and must leave 0 File records."""
+    db = seeded_db["db"]
+    folder = seeded_db["folder"]
+
+    update_folder_in_db(db, folder.id, FolderUpdateRequest(external_storage_name=None))
+    # Second call — folder already has external_storage_name=None; no files to delete
+    update_folder_in_db(db, folder.id, FolderUpdateRequest(external_storage_name=None))
+
+    assert db.query(File).filter_by(folder_id=folder.id).count() == 0

--- a/src/tests/test_unmount_external_folder.py
+++ b/src/tests/test_unmount_external_folder.py
@@ -210,3 +210,54 @@ def test_unmount_is_idempotent(seeded_db):
     update_folder_in_db(db, folder.id, FolderUpdateRequest(external_storage_name=None))
 
     assert db.query(File).filter_by(folder_id=folder.id).count() == 0
+
+
+def test_unmount_clears_external_base_path_even_when_not_in_request(sqlite_session, tmp_path):
+    """Unmounting by sending only external_storage_name=null must also clear
+    external_base_path, even if it was not included in the request body.
+
+    Regression: previously the CRUD only updated fields present in model_fields_set,
+    so a stale external_base_path would remain after unmounting.
+    """
+    db = sqlite_session
+
+    user = User(
+        username="tester2",
+        display_name="Tester2",
+        email="t2@example.com",
+        password_hash="x",
+        auth_method="local",
+        uuid=uuid_module.uuid4(),
+    )
+    db.add(user)
+    db.flush()
+
+    storage = ExternalStorage(
+        name="store2",
+        mount_point=str(tmp_path),
+        description=None,
+    )
+    db.add(storage)
+    db.flush()
+
+    folder = Folder(
+        display_name="folder2",
+        uuid=uuid_module.uuid4(),
+        user_id=user.id,
+        external_storage_name="store2",
+        external_base_path="cases/2024",  # non-null base path
+    )
+    db.add(folder)
+    db.commit()
+
+    # Send only external_storage_name=null — external_base_path is NOT in the request.
+    request = FolderUpdateRequest(external_storage_name=None)
+    assert "external_base_path" not in request.model_fields_set
+
+    updated = update_folder_in_db(db, folder.id, request)
+
+    assert updated.external_storage_name is None
+    assert updated.external_base_path is None, (
+        "external_base_path must be cleared when external_storage_name is set to null, "
+        "even if external_base_path was not explicitly included in the request."
+    )


### PR DESCRIPTION
# External Read-Only Data Stores

## Problem

OpenRelik investigations frequently involve large evidence sets that already exist on
network-attached storage — SMB shares, NFS mounts, pre-staged case drives. The only way to work
with those files today is to copy them into the main OpenRelik volume first. For large datasets
this wastes significant disk space, doubles ingestion time, and creates a second copy that must
be managed. There is no mechanism to reference files in-place as read-only artifacts that workers
can consume without the platform taking ownership.

---

## Solution

This PR introduces **External Read-Only Data Stores**: a named registry of host/container mount
points that OpenRelik can reference without copying any data.

A new `ExternalStorage` record maps a logical name (e.g. `case_smb`) to an absolute path on the
host (e.g. `/mnt/cases`). Files from that store are registered as ordinary `File` ORM objects
with two new fields (`external_storage_name`, `external_relative_path`). The existing `File.path`
hybrid property resolves the on-disk location at runtime; the `after_delete` listener skips disk
I/O for external files, so the originals are never touched.

Registration can happen in two ways:

1. **Individual file registration** — POST a single `relative_path` to
   `/api/v1/datastores/{name}/files`.
2. **Folder-level lazy mount** — PATCH a folder with `external_storage_name` + optional
   `external_base_path`. Every subsequent `GET /api/v1/folders/{id}/files/` call walks the
   directory tree and registers any new files it finds (idempotent, symlinks skipped).

Path traversal and symlink escapes are rejected at every entry point (`..` components,
`os.realpath` containment checks).

---

## Changes

### New model and table — `ExternalStorage`

- `src/datastores/sql/models/external_storage.py` — SQLAlchemy ORM model with `name` (unique,
  indexed), `mount_point`, and optional `description`. Inherits the standard `BaseModel`
  soft-delete columns.

### Database migrations

Two sequential migrations — run `alembic upgrade head` to apply both.

| Revision | What it does |
|---|---|
| `e3f1a2b4c5d6` | Creates the `externalstorage` table; adds `external_storage_name` (FK) and `external_relative_path` columns to `file`. |
| `b20df176dd1b` | Adds `external_storage_name` (FK, indexed) and `external_base_path` to `folder`; deduplicates any pre-existing duplicate external file rows; adds unique constraint `uq_file_folder_external (folder_id, external_storage_name, external_relative_path)`. |

### Changes to existing models

**`File`** (`src/datastores/sql/models/file.py`):
- New columns: `external_storage_name` (FK → `externalstorage.name`), `external_relative_path`.
- New `is_external` property — returns `True` when `external_storage_name` is set.
- `path` hybrid property now resolves external files first (mount point + relative path), with
  `..` traversal guard raising `ValueError`.
- `after_delete` listener returns early for external files — no disk deletion.
- Unique constraint `uq_file_folder_external` prevents duplicate lazy registrations.

**`Folder`** (`src/datastores/sql/models/folder.py`):
- New columns: `external_storage_name` (FK, indexed), `external_base_path`.
- New `external_storage` relationship for eager loading.

### New API router — `/api/v1/datastores/`

`src/api/v1/external_storages.py`

| Method | Path | Description |
|---|---|---|
| `GET` | `/api/v1/datastores/` | List all external storage configs. |
| `POST` | `/api/v1/datastores/` | Create a new external storage. Returns `409` if name already exists. |
| `GET` | `/api/v1/datastores/{name}` | Get a storage config by name. |
| `PATCH` | `/api/v1/datastores/{name}` | Update `mount_point` and/or `description`. |
| `DELETE` | `/api/v1/datastores/{name}` | Delete a storage config; unmounts all folders and removes all associated `File` DB records. Physical files are never deleted. |
| `POST` | `/api/v1/datastores/{name}/files` | Register a single file from the storage into the VFS (no data copied). |
| `GET` | `/api/v1/datastores/{name}/browse?path=` | List directory contents inside the storage. Sorted directories-first, then files, alphabetically. |

Existing endpoints modified:
- `PATCH /api/v1/folders/{id}` — accepts `external_storage_name` and `external_base_path`.
- `GET /api/v1/folders/{id}` — returns both fields.
- `GET /api/v1/folders/{id}/files/` — triggers lazy registration when the folder has an active
  mount.

### New Pydantic schemas (`src/api/v1/schemas.py`)

- `ExternalStorageCreate`, `ExternalStorageUpdate`, `ExternalStorageResponse`
- `ExternalFileRegisterRequest`
- `BrowseItem`, `BrowseResponse`
- `FileResponse` and `FileResponseCompactList` extended with `is_external`,
  `external_storage_name`, `external_relative_path`.
- `FolderUpdateRequest` and `FolderResponse` extended with `external_storage_name`,
  `external_base_path`.

### Test coverage

Five new test modules, ~1 800 lines total, 55 test functions:

| File | Tests | Coverage area |
|---|---|---|
| `src/tests/api/v1/external_storages_test.py` | 27 | All 7 REST endpoints: CRUD, `409`/`404` error paths, path traversal rejection, browse sorting, file registration, cascade delete. |
| `src/tests/test_sync_external_mount.py` | 13 | Lazy folder sync: new files detected, idempotency on re-sync, symlink skipping, unmount cleanup, concurrent duplicate prevention. |
| `src/tests/test_delete_external_storage.py` | 8 | Cascade on storage deletion: folders unmounted, file records removed, disk files untouched; soft-deleted record handling. |
| `src/tests/test_unmount_external_folder.py` | 7 | Folder unmount: records deleted from DB, normal files unaffected, null-safe behavior. |
| `src/tests/test_external_storage_path.py` | 10 | `File.path` resolution: correct path construction, leading-slash stripping, `..` traversal raises `ValueError`, missing relationship raises `ValueError`. `is_external` property. |

---

## How to test

### 1. Apply migrations

```bash
cd src && poetry run alembic upgrade head
```

### 2. Create a test mount directory

```bash
mkdir -p /tmp/test-mount
echo "hello" > /tmp/test-mount/evidence.txt
mkdir -p /tmp/test-mount/subdir
echo "world" > /tmp/test-mount/subdir/second.txt
```

### 3. Start the server

```bash
OPENRELIK_SERVER_SETTINGS=./settings_example.toml \
  poetry run uvicorn main:app --host 0.0.0.0 --port 8710 --app-dir src
```

### 4. Register a storage

```bash
curl -s -X POST http://localhost:8710/api/v1/datastores/ \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"test","mount_point":"/tmp/test-mount","description":"local test"}'
# Expect: 201 with the new ExternalStorageResponse JSON
```

### 5. Browse the mount

```bash
curl -s "http://localhost:8710/api/v1/datastores/test/browse" \
  -H "Authorization: Bearer $TOKEN"
# Expect: directories listed before files, alphabetically within each group
# {"current_path":"","items":[{"name":"subdir","type":"directory","size":null},
#                              {"name":"evidence.txt","type":"file","size":6}]}

curl -s "http://localhost:8710/api/v1/datastores/test/browse?path=subdir" \
  -H "Authorization: Bearer $TOKEN"
# Expect: {"current_path":"subdir","items":[{"name":"second.txt","type":"file","size":6}]}
```

### 6. Register a single file

```bash
curl -s -X POST http://localhost:8710/api/v1/datastores/test/files \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"folder_id": FOLDER_ID, "relative_path": "evidence.txt"}'
# Expect: FileResponse with is_external=true and external_storage_name="test"
```

### 7. Test lazy folder mount

```bash
# Mount the storage to a folder
curl -s -X PATCH http://localhost:8710/api/v1/folders/FOLDER_ID \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"external_storage_name":"test"}'

# List files — triggers lazy registration of the full directory tree
curl -s http://localhost:8710/api/v1/folders/FOLDER_ID/files/ \
  -H "Authorization: Bearer $TOKEN"
# Expect: evidence.txt and subdir/second.txt listed with is_external=true

# Re-request — should return the same list without creating duplicates
curl -s http://localhost:8710/api/v1/folders/FOLDER_ID/files/ \
  -H "Authorization: Bearer $TOKEN"
```

### 8. Verify no disk deletion

Delete the registered file record via the API and confirm the original file is untouched:

```bash
curl -s -X DELETE http://localhost:8710/api/v1/files/FILE_ID \
  -H "Authorization: Bearer $TOKEN"

ls /tmp/test-mount/evidence.txt
# Must still exist
```

### 9. Test cascade delete

```bash
curl -s -X DELETE http://localhost:8710/api/v1/datastores/test \
  -H "Authorization: Bearer $TOKEN"
# Expect: 204

# Folder should now have external_storage_name=null
curl -s http://localhost:8710/api/v1/folders/FOLDER_ID \
  -H "Authorization: Bearer $TOKEN"
# Expect: external_storage_name=null, external_base_path=null

# Physical files must still exist
ls /tmp/test-mount/
```

### 10. Run the test suite

```bash
OPENRELIK_SERVER_SETTINGS=./settings_example.toml REDIS_URL=redis://test:1234 \
  poetry run pytest \
    src/tests/test_external_storage_path.py \
    src/tests/test_delete_external_storage.py \
    src/tests/test_sync_external_mount.py \
    src/tests/test_unmount_external_folder.py \
    src/tests/api/v1/external_storages_test.py \
    -v
```

---

## Notes

- **Breaking changes:** None. All new columns are nullable; existing `File` and `Folder` records
  are unaffected.
- **Migration required:** Yes — run `alembic upgrade head`. Two sequential migrations are applied
  (`e3f1a2b4c5d6` then `b20df176dd1b`). The second migration includes a safe deduplication step
  for any pre-existing duplicate external file rows.
- **Security:** Path traversal is rejected at both the API layer (`..` component check) and the
  model layer (`os.realpath` containment). Symlinks are never followed during browse or lazy sync.
- **Companion PRs:** This server PR requires matching changes in **openrelik-ui** (read-only badge
  rendering, browse/mount UI) and **openrelik-deploy** (volume mount configuration for the server
  container). All three PRs should be merged together.
- **Empty directories are not shown.** The virtual folder tree is built from registered 
  file records. If an external storage directory contains only subdirectories with no files, 
  those subdirectories will not appear in the UI until at least one file exists within them. 
  Use the **Refresh** button to sync new files after they are added to the external storage.
- **Related PRs:** [openrelik-ui#115](https://github.com/openrelik/openrelik-ui/pull/115), [openrelik-deploy#20](https://github.com/openrelik/openrelik-deploy/pull/20)