### PR TITLE
Extract workflow create/run into lib/workflow_utils

### DIFF
--- a/src/api/v1/workflows.py
+++ b/src/api/v1/workflows.py
@@ -15,16 +15,8 @@
 import asyncio
 import functools
 import json
-import os
 from typing import List
-from uuid import uuid4
 
-from celery import chain as celery_chain
-from celery import chord as celery_chord
-from celery import group as celery_group
-from celery import signature
-from celery.app import Celery
-from celery.canvas import Signature
 from fastapi import APIRouter, Depends, HTTPException, status
 from openrelik_ai_common.providers import manager
 from sqlalchemy.orm import Session
@@ -34,7 +26,6 @@ from config import get_active_llm
 from datastores.sql.crud.authz import require_access
 from datastores.sql.crud.folder import create_subfolder_in_db
 from datastores.sql.crud.workflow import (
-    create_task_in_db,
     create_workflow_in_db,
     create_workflow_template_in_db,
     delete_workflow_from_db,
@@ -47,222 +38,19 @@ from datastores.sql.crud.workflow import (
 )
 from datastores.sql.database import get_db_connection
 from datastores.sql.models.role import Role
-from datastores.sql.models.workflow import Task
 from lib import workflow_utils
 from lib.reporting_utils import create_workflow_report
+from lib.workflow_utils import TemplateNotFoundError, replace_uuids
 
 from datastores.sql.crud.authz import check_user_access
 
 from . import schemas
-
-redis_url = os.getenv("REDIS_URL")
-celery = Celery(broker=redis_url, backend=redis_url)
 
 # Workflows in a folder context.
 router = APIRouter()
 
 # Router for resources that live under /workflows, i.e. outside of a folder context.
 router_root = APIRouter()
-
-
-def get_task_signature(
-    db: Session,
-    current_user: schemas.User,
-    task_data: dict,
-    input_files: list,
-    output_path: str,
-    workflow: schemas.Workflow,
-) -> Signature:
-    """Returns a Celery task signature for a given task.
-
-    Args:
-        db (Session): The database session.
-        current_user (schemas.User): The current user.
-        task_data (dict): The task data.
-        input_files (list): A list of input files.
-        output_path (str): The output path.
-        workflow (schemas.Workflow): The workflow.
-
-    Returns:
-        Signature: The Celery task signature.
-    """
-    task_uuid = task_data.get("uuid", uuid4().hex)
-    task_config = {
-        option["name"]: option.get("value") for option in task_data.get("task_config", {})
-    }
-
-    # Create a new DB task
-    new_task_db = Task(
-        display_name=task_data.get("display_name"),
-        description=task_data.get("description"),
-        config=json.dumps(task_config),
-        uuid=task_uuid,
-        user=current_user,
-        workflow=workflow,
-    )
-    create_task_in_db(db, new_task_db)
-
-    task_signature = signature(
-        task_data.get("task_name"),
-        kwargs={
-            "input_files": input_files,
-            "output_path": output_path,
-            "workflow_id": workflow.id,
-            "task_config": task_config,
-        },
-        queue=task_data.get("queue_name"),
-        task_id=task_uuid,
-    )
-    return task_signature
-
-
-def create_workflow_signature(
-    db: Session,
-    current_user: schemas.User,
-    task_data: dict,
-    input_files: list,
-    output_path: str,
-    workflow: schemas.Workflow,
-) -> Signature:
-    """Creates a Celery workflow signature for a given task definition
-
-    This function recursively constructs a Celery workflow signature based on the
-    provided `task_data`, which represents a structured description of tasks and their
-    dependencies. It supports two primary task types: 'chain' and 'task'.
-
-    chain: Represents a sequence of tasks executed in order.
-        -   If the chain contains multiple tasks, a Celery `celery_group` is created to
-            execute them concurrently. celery_group allows multiple tasks to be run
-            in parallel.
-        -   If only one task is present, a Celery `celery_chain` is created to execute
-            it *serially*. `celery_chain` ensures tasks are executed one after another,
-            ith the output of one task becoming the input of the next.
-
-    task: Represents a single, executable task.
-        - It retrieves the corresponding Celery task signature using get_task_signature.
-        - If the task has sub-tasks, they are incorporated into the workflow using
-          Celery `celery_chain` and `celery_group` constructs, depending on the number
-          of sub-tasks. The primary task is chained with the subtasks.
-
-    The function effectively translates a hierarchical task description into a Celery
-    workflow that can be executed asynchronously. This allows for complex workflows to
-    be defined and executed in a distributed manner.
-
-    Args:
-        db (Session): The database session.
-        current_user (schemas.User): The current user.
-        task_data (dict): The task data.
-        input_files (list): A list of input files.
-        output_path (str): The output path.
-        workflow (schemas.Workflow): The workflow.
-
-    Returns:
-        Signature: The Celery workflow signature.
-
-    Raises:
-        ValueError: If the task type is not supported.
-    """
-    if task_data["type"] == "chain":
-        if len(task_data["tasks"]) > 1:
-            return celery_group(
-                create_workflow_signature(
-                    db, current_user, task, input_files, output_path, workflow
-                )
-                for task in task_data["tasks"]
-            )
-        else:
-            return celery_chain(
-                create_workflow_signature(
-                    db,
-                    current_user,
-                    task_data["tasks"][0],
-                    input_files,
-                    output_path,
-                    workflow,
-                )
-            )
-
-    elif task_data["type"] == "chord":
-        header_tasks = [
-            create_workflow_signature(db, current_user, t, input_files, output_path, workflow)
-            for t in task_data.get("tasks", [])
-        ]
-
-        callback_task_data = task_data.get("callback")
-        if not callback_task_data:
-            raise ValueError("Chord definition requires a 'callback' task.")
-
-        callback_signature = create_workflow_signature(
-            db, current_user, callback_task_data, input_files, output_path, workflow
-        )
-
-        return celery_chord(header_tasks, callback_signature)
-
-    elif task_data["type"] == "task":
-        task_signature = get_task_signature(
-            db, current_user, task_data, input_files, output_path, workflow
-        )
-        if task_data["tasks"]:
-            if len(task_data["tasks"]) > 1:
-                return celery_chain(
-                    task_signature,
-                    celery_group(
-                        create_workflow_signature(
-                            db, current_user, t, input_files, output_path, workflow
-                        )
-                        for t in task_data["tasks"]
-                    ),
-                )
-            else:
-                return celery_chain(
-                    task_signature,
-                    create_workflow_signature(
-                        db,
-                        current_user,
-                        task_data["tasks"][0],
-                        input_files,
-                        output_path,
-                        workflow,
-                    ),
-                )
-        else:
-            return task_signature
-    else:
-        raise ValueError(f"Unsupported task type: {task_data['type']}")
-
-
-def replace_uuids(data: dict | list, replace_with: str = None) -> dict | list:
-    """Recursively replaces UUID keys within a dictionary or list structure.
-
-    This function traverses the provided `data` structure (which can be a dictionary or
-    list) and replaces any dictionary keys named "uuid" with a new value.
-
-    If `replace_with` is not provided (or is None), a newly generated UUID is used as
-    the replacement. If `replace_with` is provided, that value is used as the
-    replacement for all "uuid" keys.
-
-    This is needed when modifying workflow specifications that contain UUIDs, ensuring
-    that each instance has unique identifiers.
-
-    Args:
-        data (dict | list): The dictionary or list to traverse and modify.
-        replace_with (str, optional): The value to replace UUIDs with. Defaults to None.
-
-    Returns:
-        dict | list: The modified dictionary or list with UUIDs replaced.
-    """
-    if isinstance(data, dict):
-        for key, value in data.items():
-            if key == "uuid":
-                if not replace_with:
-                    data[key] = uuid4().hex
-                else:
-                    data[key] = replace_with
-            else:
-                replace_uuids(value)
-    elif isinstance(data, list):
-        for item in data:
-            replace_uuids(item)
 
 
 # Create workflow
@@ -294,40 +82,20 @@ async def create_workflow(
     Returns:
         schemas.WorkflowResponse: The created workflow.
     """
-    default_workflow_display_name = "Untitled workflow"
-    default_spec_json = None
-
-    from_template = None
-
-    if request_body.template_id:
-        from_template = get_workflow_template_from_db(db, request_body.template_id)
-        default_workflow_display_name = from_template.display_name
-        spec_json = json.loads(from_template.spec_json)
-        # Replace UUIDs with placeholder value for the template
-        replace_uuids(spec_json)
-        # Add parameter values to task_config items
-        if request_body.template_params:
-            workflow_utils.update_task_config_values(spec_json, request_body.template_params)
-
-        default_spec_json = json.dumps(spec_json)
-
-    # Create new folder for workflow results
-    new_folder = schemas.FolderCreateRequest(
-        display_name=default_workflow_display_name, parent_id=request_body.folder_id
-    )
-    new_workflow_folder = create_subfolder_in_db(db, folder_id, new_folder, current_user)
-
-    # Create new workflow
-    new_workflow_db = schemas.Workflow(
-        display_name=default_workflow_display_name,
-        user_id=current_user.id,
-        spec_json=default_spec_json,
-        file_ids=request_body.file_ids,
-        folder_id=new_workflow_folder.id,
-        template_id=from_template.id if from_template else None,
-    )
-    new_workflow = create_workflow_in_db(db, new_workflow_db)
-    return new_workflow
+    try:
+        return workflow_utils.create_workflow_from_template(
+            db,
+            folder_id=folder_id,
+            file_ids=request_body.file_ids,
+            template_id=request_body.template_id,
+            template_params=request_body.template_params,
+            user=current_user,
+        )
+    except TemplateNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
 
 
 # Get all workflows for a folder
@@ -534,44 +302,13 @@ async def run_workflow(
     Returns:
         schemas.WorkflowResponse: The workflow.
     """
-    workflow_spec = request_body.workflow_spec
-    workflow_spec_json = json.dumps(workflow_spec)
     workflow = get_workflow_from_db(db, workflow_id)
-    # Update workflow spec
-    workflow.spec_json = workflow_spec_json
-
-    input_files = [
-        {
-            "id": file.id,
-            "uuid": file.uuid.hex,
-            "display_name": file.display_name,
-            "extension": file.extension,
-            "data_type": file.data_type,
-            "mime_type": file.magic_mime,
-            "path": file.path,
-        }
-        for file in workflow.files
-    ]
-
-    output_path = workflow.folder.path
-    if not os.path.exists(output_path):
-        os.makedirs(output_path)
-
-    celery_workflow = create_workflow_signature(
+    return workflow_utils.run_workflow(
         db,
-        current_user,
-        workflow_spec.get("workflow"),
-        input_files,
-        output_path,
-        workflow,
+        workflow=workflow,
+        workflow_spec=request_body.workflow_spec,
+        user=current_user,
     )
-    celery_workflow.apply_async()
-
-    db.add(workflow)
-    db.commit()
-    db.refresh(workflow)
-
-    return workflow
 
 
 # Get workflow status

--- a/src/api/v1/workflows.py
+++ b/src/api/v1/workflows.py
@@ -83,7 +83,7 @@ async def create_workflow(
         schemas.WorkflowResponse: The created workflow.
     """
     try:
-        return workflow_utils.create_workflow_from_template(
+        return workflow_utils.create_workflow(
             db,
             folder_id=folder_id,
             file_ids=request_body.file_ids,

--- a/src/datastores/sql/crud/workflow.py
+++ b/src/datastores/sql/crud/workflow.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 from api.v1 import schemas
 from datastores.sql.crud.file import get_file_from_db
 from datastores.sql.models.workflow import Task, TaskReport, Workflow, WorkflowTemplate
-from lib import workflow_utils
+from lib.workflow_spec_utils import add_unique_parameter_names
 
 
 def get_file_workflows_from_db(db: Session, file_id: int) -> list[Workflow]:
@@ -185,7 +185,7 @@ def get_workflow_templates_from_db(db: Session) -> list[WorkflowTemplate]:
                 try:
                     # Parse the JSON and add the param_name
                     spec_json_dict = json.loads(template.spec_json)
-                    workflow_utils.add_unique_parameter_names(spec_json_dict)
+                    add_unique_parameter_names(spec_json_dict)
 
                     # Update the database record
                     template.spec_json = json.dumps(spec_json_dict)

--- a/src/lib/workflow_spec_utils.py
+++ b/src/lib/workflow_spec_utils.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-Python helpers that manipulate workflow spec dictionaries.
+
+Kept separate from ``lib.workflow_utils`` so modules in the CRUD layer can
+depend on spec-manipulation helpers without pulling in SQLAlchemy/Celery
+dependencies (which would create an import cycle).
+"""
+
+from collections import defaultdict
+
+
+def add_unique_parameter_names(data: dict | list) -> None:
+    """
+    Wrapper function to initiate the recursive traversal with a shared counter.
+
+    Args:
+        data (dict | list): The workflow dictionary to modify.
+    """
+    _add_unique_parameter_names_recursive(data, defaultdict(int))
+
+
+def _add_unique_parameter_names_recursive(data: dict | list, counts: defaultdict) -> None:
+    """
+    Recursively traverses a workflow dictionary and adds a unique
+    "param_name" key to each task_config item that has a "name" key.
+    The "param_name" is created by lowercasing the original name and
+    replacing spaces with underscores, followed by a unique index.
+
+    Args:
+        data (dict | list): The workflow dictionary to modify.
+        counts (defaultdict): A dictionary to keep track of the counts of each normalized name.
+    """
+    if isinstance(data, dict):
+        if "task_config" in data and isinstance(data["task_config"], list):
+            for item in data["task_config"]:
+                if "name" in item:
+                    normalized_name = item["name"].lower().replace(" ", "_")
+                    param_name = f"{normalized_name}_{counts[normalized_name]}"
+                    item["param_name"] = param_name
+                    counts[normalized_name] += 1
+
+        for key, value in data.items():
+            _add_unique_parameter_names_recursive(value, counts)
+
+    elif isinstance(data, list):
+        for item in data:
+            _add_unique_parameter_names_recursive(item, counts)

--- a/src/lib/workflow_spec_utils.py
+++ b/src/lib/workflow_spec_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pure-Python helpers that manipulate workflow spec dictionaries.
-
-Kept separate from ``lib.workflow_utils`` so modules in the CRUD layer can
-depend on spec-manipulation helpers without pulling in SQLAlchemy/Celery
-dependencies (which would create an import cycle).
-"""
+"""Helpers that manipulate workflow spec dictionaries."""
 
 from collections import defaultdict
 

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Workflow helpers reusable by the HTTP layer and in-process callers.
-
-These functions do not depend on FastAPI; they exist so that both
-``api.v1.workflows`` (HTTP) and, in the future, the bundled importers can
-create and run workflows without going through the REST API.
-"""
+"""Workflow helpers to create, manipulate or run workflows."""
 
 import json
 import os
@@ -42,6 +37,7 @@ from datastores.sql.crud.workflow import (
 from datastores.sql.models.workflow import Task, Workflow
 
 
+# Redis URL and Celery app initialization.
 _redis_url = os.getenv("REDIS_URL")
 celery_app = Celery(broker=_redis_url, backend=_redis_url)
 
@@ -66,7 +62,7 @@ def update_task_config_values(data: dict | list, parameters: dict) -> None:
                 item["value"] = parameters[param_name]
                 continue
 
-        for key, value in data.items():
+        for _, value in data.items():
             update_task_config_values(value, parameters)
 
     elif isinstance(data, list):

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -42,9 +42,6 @@ from datastores.sql.crud.workflow import (
 from datastores.sql.models.workflow import Task, Workflow
 
 
-# Celery app shared by everything that dispatches workflow signatures.
-# Constructed at import time to match the behavior of the previous module-level
-# instance in ``api.v1.workflows``.
 _redis_url = os.getenv("REDIS_URL")
 celery_app = Celery(broker=_redis_url, backend=_redis_url)
 
@@ -290,12 +287,7 @@ def create_workflow_from_template(
     template_params: Optional[dict],
     user: schemas.User,
 ) -> Workflow:
-    """Create a workflow row (optionally from a template) and return it.
-
-    Mirrors the behavior of the HTTP ``POST /folders/{folder_id}/workflows/``
-    route minus the request-parsing shell. No authorization is performed;
-    the caller is trusted (either an authenticated HTTP route that has
-    already checked access, or an in-process invoker such as an importer).
+    """Create a Workflow (optionally from a template) and return it.
 
     Raises:
         TemplateNotFoundError: When ``template_id`` is provided but the
@@ -344,11 +336,14 @@ def run_workflow(
     workflow_spec: dict,
     user: schemas.User,
 ) -> Workflow:
-    """Persist ``workflow_spec`` on ``workflow`` and dispatch it via Celery.
+    """Runs a workflow via Celery.
 
     Builds input-file dicts from ``workflow.files``, ensures the output
     directory exists, constructs the Celery canvas, and calls
-    ``apply_async()``. Returns the refreshed workflow row.
+    ``apply_async()``.
+    
+    Returns:
+        A Workflow instance representing the workflow that was run.
     """
     workflow.spec_json = json.dumps(workflow_spec)
 

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2025-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
+"""Workflow helpers reusable by the HTTP layer and in-process callers.
+
+These functions do not depend on FastAPI; they exist so that both
+``api.v1.workflows`` (HTTP) and, in the future, the bundled importers can
+create and run workflows without going through the REST API.
+"""
+
+import json
+import os
+from typing import Optional
+from uuid import uuid4
+
+from celery import chain as celery_chain
+from celery import chord as celery_chord
+from celery import group as celery_group
+from celery import signature
+from celery.app import Celery
+from celery.canvas import Signature
+from sqlalchemy.orm import Session
+
+from api.v1 import schemas
+from datastores.sql.crud.folder import create_subfolder_in_db
+from datastores.sql.crud.workflow import (
+    create_task_in_db,
+    create_workflow_in_db,
+    get_workflow_template_from_db,
+)
+from datastores.sql.models.workflow import Task, Workflow
+
+
+# Celery app shared by everything that dispatches workflow signatures.
+# Constructed at import time to match the behavior of the previous module-level
+# instance in ``api.v1.workflows``.
+_redis_url = os.getenv("REDIS_URL")
+celery_app = Celery(broker=_redis_url, backend=_redis_url)
 
 
 def update_task_config_values(data: dict | list, parameters: dict) -> None:
@@ -43,39 +77,310 @@ def update_task_config_values(data: dict | list, parameters: dict) -> None:
             update_task_config_values(item, parameters)
 
 
-def add_unique_parameter_names(data: dict | list) -> None:
-    """
-    Wrapper function to initiate the recursive traversal with a shared counter.
+def get_task_signature(
+    db: Session,
+    current_user: schemas.User,
+    task_data: dict,
+    input_files: list,
+    output_path: str,
+    workflow: schemas.Workflow,
+) -> Signature:
+    """Returns a Celery task signature for a given task.
 
     Args:
-        data (dict | list): The workflow dictionary to modify.
+        db (Session): The database session.
+        current_user (schemas.User): The current user.
+        task_data (dict): The task data.
+        input_files (list): A list of input files.
+        output_path (str): The output path.
+        workflow (schemas.Workflow): The workflow.
+
+    Returns:
+        Signature: The Celery task signature.
     """
-    _add_unique_parameter_names_recursive(data, defaultdict(int))
+    task_uuid = task_data.get("uuid", uuid4().hex)
+    task_config = {
+        option["name"]: option.get("value") for option in task_data.get("task_config", {})
+    }
+
+    # Create a new DB task
+    new_task_db = Task(
+        display_name=task_data.get("display_name"),
+        description=task_data.get("description"),
+        config=json.dumps(task_config),
+        uuid=task_uuid,
+        user=current_user,
+        workflow=workflow,
+    )
+    create_task_in_db(db, new_task_db)
+
+    task_signature = signature(
+        task_data.get("task_name"),
+        kwargs={
+            "input_files": input_files,
+            "output_path": output_path,
+            "workflow_id": workflow.id,
+            "task_config": task_config,
+        },
+        queue=task_data.get("queue_name"),
+        task_id=task_uuid,
+    )
+    return task_signature
 
 
-def _add_unique_parameter_names_recursive(data: dict | list, counts: defaultdict) -> None:
-    """
-    Recursively traverses a workflow dictionary and adds a unique
-    "param_name" key to each task_config item that has a "name" key.
-    The "param_name" is created by lowercasing the original name and
-    replacing spaces with underscores, followed by a unique index.
+def create_workflow_signature(
+    db: Session,
+    current_user: schemas.User,
+    task_data: dict,
+    input_files: list,
+    output_path: str,
+    workflow: schemas.Workflow,
+) -> Signature:
+    """Creates a Celery workflow signature for a given task definition
+
+    This function recursively constructs a Celery workflow signature based on the
+    provided `task_data`, which represents a structured description of tasks and their
+    dependencies. It supports two primary task types: 'chain' and 'task'.
+
+    chain: Represents a sequence of tasks executed in order.
+        -   If the chain contains multiple tasks, a Celery `celery_group` is created to
+            execute them concurrently. celery_group allows multiple tasks to be run
+            in parallel.
+        -   If only one task is present, a Celery `celery_chain` is created to execute
+            it *serially*. `celery_chain` ensures tasks are executed one after another,
+            ith the output of one task becoming the input of the next.
+
+    task: Represents a single, executable task.
+        - It retrieves the corresponding Celery task signature using get_task_signature.
+        - If the task has sub-tasks, they are incorporated into the workflow using
+          Celery `celery_chain` and `celery_group` constructs, depending on the number
+          of sub-tasks. The primary task is chained with the subtasks.
+
+    The function effectively translates a hierarchical task description into a Celery
+    workflow that can be executed asynchronously. This allows for complex workflows to
+    be defined and executed in a distributed manner.
 
     Args:
-        data (dict | list): The workflow dictionary to modify.
-        counts (defaultdict): A dictionary to keep track of the counts of each normalized name.
+        db (Session): The database session.
+        current_user (schemas.User): The current user.
+        task_data (dict): The task data.
+        input_files (list): A list of input files.
+        output_path (str): The output path.
+        workflow (schemas.Workflow): The workflow.
+
+    Returns:
+        Signature: The Celery workflow signature.
+
+    Raises:
+        ValueError: If the task type is not supported.
+    """
+    if task_data["type"] == "chain":
+        if len(task_data["tasks"]) > 1:
+            return celery_group(
+                create_workflow_signature(
+                    db, current_user, task, input_files, output_path, workflow
+                )
+                for task in task_data["tasks"]
+            )
+        else:
+            return celery_chain(
+                create_workflow_signature(
+                    db,
+                    current_user,
+                    task_data["tasks"][0],
+                    input_files,
+                    output_path,
+                    workflow,
+                )
+            )
+
+    elif task_data["type"] == "chord":
+        header_tasks = [
+            create_workflow_signature(db, current_user, t, input_files, output_path, workflow)
+            for t in task_data.get("tasks", [])
+        ]
+
+        callback_task_data = task_data.get("callback")
+        if not callback_task_data:
+            raise ValueError("Chord definition requires a 'callback' task.")
+
+        callback_signature = create_workflow_signature(
+            db, current_user, callback_task_data, input_files, output_path, workflow
+        )
+
+        return celery_chord(header_tasks, callback_signature)
+
+    elif task_data["type"] == "task":
+        task_signature = get_task_signature(
+            db, current_user, task_data, input_files, output_path, workflow
+        )
+        if task_data["tasks"]:
+            if len(task_data["tasks"]) > 1:
+                return celery_chain(
+                    task_signature,
+                    celery_group(
+                        create_workflow_signature(
+                            db, current_user, t, input_files, output_path, workflow
+                        )
+                        for t in task_data["tasks"]
+                    ),
+                )
+            else:
+                return celery_chain(
+                    task_signature,
+                    create_workflow_signature(
+                        db,
+                        current_user,
+                        task_data["tasks"][0],
+                        input_files,
+                        output_path,
+                        workflow,
+                    ),
+                )
+        else:
+            return task_signature
+    else:
+        raise ValueError(f"Unsupported task type: {task_data['type']}")
+
+
+def replace_uuids(data: dict | list, replace_with: str = None) -> dict | list:
+    """Recursively replaces UUID keys within a dictionary or list structure.
+
+    This function traverses the provided `data` structure (which can be a dictionary or
+    list) and replaces any dictionary keys named "uuid" with a new value.
+
+    If `replace_with` is not provided (or is None), a newly generated UUID is used as
+    the replacement. If `replace_with` is provided, that value is used as the
+    replacement for all "uuid" keys.
+
+    This is needed when modifying workflow specifications that contain UUIDs, ensuring
+    that each instance has unique identifiers.
+
+    Args:
+        data (dict | list): The dictionary or list to traverse and modify.
+        replace_with (str, optional): The value to replace UUIDs with. Defaults to None.
+
+    Returns:
+        dict | list: The modified dictionary or list with UUIDs replaced.
     """
     if isinstance(data, dict):
-        if "task_config" in data and isinstance(data["task_config"], list):
-            for item in data["task_config"]:
-                if "name" in item:
-                    normalized_name = item["name"].lower().replace(" ", "_")
-                    param_name = f"{normalized_name}_{counts[normalized_name]}"
-                    item["param_name"] = param_name
-                    counts[normalized_name] += 1
-
         for key, value in data.items():
-            _add_unique_parameter_names_recursive(value, counts)
-
+            if key == "uuid":
+                if not replace_with:
+                    data[key] = uuid4().hex
+                else:
+                    data[key] = replace_with
+            else:
+                replace_uuids(value)
     elif isinstance(data, list):
         for item in data:
-            _add_unique_parameter_names_recursive(item, counts)
+            replace_uuids(item)
+
+
+class TemplateNotFoundError(ValueError):
+    """Raised when ``create_workflow_from_template`` cannot resolve a template id."""
+
+
+def create_workflow_from_template(
+    db: Session,
+    *,
+    folder_id: int,
+    file_ids: list[int],
+    template_id: Optional[int],
+    template_params: Optional[dict],
+    user: schemas.User,
+) -> Workflow:
+    """Create a workflow row (optionally from a template) and return it.
+
+    Mirrors the behavior of the HTTP ``POST /folders/{folder_id}/workflows/``
+    route minus the request-parsing shell. No authorization is performed;
+    the caller is trusted (either an authenticated HTTP route that has
+    already checked access, or an in-process invoker such as an importer).
+
+    Raises:
+        TemplateNotFoundError: When ``template_id`` is provided but the
+            template does not exist.
+    """
+    default_workflow_display_name = "Untitled workflow"
+    default_spec_json = None
+    from_template = None
+
+    if template_id:
+        from_template = get_workflow_template_from_db(db, template_id)
+        if not from_template:
+            raise TemplateNotFoundError(
+                f"Workflow template {template_id} not found"
+            )
+        default_workflow_display_name = from_template.display_name
+        spec_json = json.loads(from_template.spec_json)
+        # Replace the placeholder UUIDs seeded in the template with fresh ones
+        # so each workflow instance has unique identifiers.
+        replace_uuids(spec_json)
+        if template_params:
+            update_task_config_values(spec_json, template_params)
+        default_spec_json = json.dumps(spec_json)
+
+    # Create a new folder to hold workflow results.
+    new_folder = schemas.FolderCreateRequest(
+        display_name=default_workflow_display_name, parent_id=folder_id
+    )
+    new_workflow_folder = create_subfolder_in_db(db, folder_id, new_folder, user)
+
+    new_workflow_db = schemas.Workflow(
+        display_name=default_workflow_display_name,
+        user_id=user.id,
+        spec_json=default_spec_json,
+        file_ids=file_ids,
+        folder_id=new_workflow_folder.id,
+        template_id=from_template.id if from_template else None,
+    )
+    return create_workflow_in_db(db, new_workflow_db)
+
+
+def run_workflow(
+    db: Session,
+    *,
+    workflow: Workflow,
+    workflow_spec: dict,
+    user: schemas.User,
+) -> Workflow:
+    """Persist ``workflow_spec`` on ``workflow`` and dispatch it via Celery.
+
+    Builds input-file dicts from ``workflow.files``, ensures the output
+    directory exists, constructs the Celery canvas, and calls
+    ``apply_async()``. Returns the refreshed workflow row.
+    """
+    workflow.spec_json = json.dumps(workflow_spec)
+
+    input_files = [
+        {
+            "id": file.id,
+            "uuid": file.uuid.hex,
+            "display_name": file.display_name,
+            "extension": file.extension,
+            "data_type": file.data_type,
+            "mime_type": file.magic_mime,
+            "path": file.path,
+        }
+        for file in workflow.files
+    ]
+
+    output_path = workflow.folder.path
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+
+    celery_workflow = create_workflow_signature(
+        db,
+        user,
+        workflow_spec.get("workflow"),
+        input_files,
+        output_path,
+        workflow,
+    )
+    celery_workflow.apply_async()
+
+    db.add(workflow)
+    db.commit()
+    db.refresh(workflow)
+
+    return workflow

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -36,7 +36,6 @@ from datastores.sql.crud.workflow import (
 )
 from datastores.sql.models.workflow import Task, Workflow
 
-
 # Redis URL and Celery app initialization.
 _redis_url = os.getenv("REDIS_URL")
 celery_app = Celery(broker=_redis_url, backend=_redis_url)
@@ -93,7 +92,8 @@ def get_task_signature(
     """
     task_uuid = task_data.get("uuid", uuid4().hex)
     task_config = {
-        option["name"]: option.get("value") for option in task_data.get("task_config", {})
+        option["name"]: option.get("value")
+        for option in task_data.get("task_config", {})
     }
 
     # Create a new DB task
@@ -189,7 +189,9 @@ def create_workflow_signature(
 
     elif task_data["type"] == "chord":
         header_tasks = [
-            create_workflow_signature(db, current_user, t, input_files, output_path, workflow)
+            create_workflow_signature(
+                db, current_user, t, input_files, output_path, workflow
+            )
             for t in task_data.get("tasks", [])
         ]
 
@@ -277,19 +279,33 @@ class TemplateNotFoundError(ValueError):
 def create_workflow_from_template(
     db: Session,
     *,
+    display_name: Optional[str] = None,
     folder_id: int,
     file_ids: list[int],
     template_id: Optional[int],
     template_params: Optional[dict],
     user: schemas.User,
-    display_name: Optional[str] = None,
 ) -> Workflow:
     """Create a Workflow (optionally from a template) and return it.
 
     Args:
-        display_name: Optional override for the workflow's (and results
-            subfolder's) display name. When None, falls back to the
-            template's display name, or "Untitled workflow" if no template.
+        db (Session): The database session.
+        display_name (Optional[str]): Optional override for the workflow's
+            (and results subfolder's) display name. When None, falls back to
+            the template's display name, or "Untitled workflow" if no
+            template.
+        folder_id (int): The ID of the parent folder that will hold the
+            workflow's results subfolder.
+        file_ids (list[int]): IDs of the files to associate with the workflow.
+        template_id (Optional[int]): Optional ID of a workflow template to
+            create the workflow from.
+        template_params (Optional[dict]): Optional dict of parameter values
+            to apply to the template's task configs. Keys should correspond
+            to the template's task config parameters.
+        user (schemas.User): The user creating the workflow.
+
+    Returns:
+        Workflow: The newly created workflow.
 
     Raises:
         TemplateNotFoundError: When ``template_id`` is provided but the
@@ -302,9 +318,7 @@ def create_workflow_from_template(
     if template_id:
         from_template = get_workflow_template_from_db(db, template_id)
         if not from_template:
-            raise TemplateNotFoundError(
-                f"Workflow template {template_id} not found"
-            )
+            raise TemplateNotFoundError(f"Workflow template {template_id} not found")
         default_workflow_display_name = from_template.display_name
         spec_json = json.loads(from_template.spec_json)
         # Replace the placeholder UUIDs seeded in the template with fresh ones
@@ -345,7 +359,7 @@ def run_workflow(
     Builds input-file dicts from ``workflow.files``, ensures the output
     directory exists, constructs the Celery canvas, and calls
     ``apply_async()``.
-    
+
     Returns:
         A Workflow instance representing the workflow that was run.
     """

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -282,8 +282,14 @@ def create_workflow_from_template(
     template_id: Optional[int],
     template_params: Optional[dict],
     user: schemas.User,
+    display_name: Optional[str] = None,
 ) -> Workflow:
     """Create a Workflow (optionally from a template) and return it.
+
+    Args:
+        display_name: Optional override for the workflow's (and results
+            subfolder's) display name. When None, falls back to the
+            template's display name, or "Untitled workflow" if no template.
 
     Raises:
         TemplateNotFoundError: When ``template_id`` is provided but the
@@ -308,14 +314,16 @@ def create_workflow_from_template(
             update_task_config_values(spec_json, template_params)
         default_spec_json = json.dumps(spec_json)
 
+    workflow_display_name = display_name or default_workflow_display_name
+
     # Create a new folder to hold workflow results.
     new_folder = schemas.FolderCreateRequest(
-        display_name=default_workflow_display_name, parent_id=folder_id
+        display_name=workflow_display_name, parent_id=folder_id
     )
     new_workflow_folder = create_subfolder_in_db(db, folder_id, new_folder, user)
 
     new_workflow_db = schemas.Workflow(
-        display_name=default_workflow_display_name,
+        display_name=workflow_display_name,
         user_id=user.id,
         spec_json=default_spec_json,
         file_ids=file_ids,

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -273,10 +273,10 @@ def replace_uuids(data: dict | list, replace_with: str = None) -> dict | list:
 
 
 class TemplateNotFoundError(ValueError):
-    """Raised when ``create_workflow_from_template`` cannot resolve a template id."""
+    """Raised when ``create_workflow`` cannot resolve a template id."""
 
 
-def create_workflow_from_template(
+def create_workflow(
     db: Session,
     *,
     display_name: Optional[str] = None,

--- a/src/tests/api/v1/workflows_test.py
+++ b/src/tests/api/v1/workflows_test.py
@@ -36,15 +36,15 @@ async def test_create_workflow(
     """Test create workflow route."""
     folder_id = 1
     mock_get_workflow_template_from_db = mocker.patch(
-        "api.v1.workflows.get_workflow_template_from_db"
+        "lib.workflow_utils.get_workflow_template_from_db"
     )
     mock_get_workflow_template_from_db.return_value = workflow_schema_mock
     mock_create_subfolder_in_db = mocker.patch(
-        "api.v1.workflows.create_subfolder_in_db"
+        "lib.workflow_utils.create_subfolder_in_db"
     )
     mock_create_subfolder_in_db.return_value = folder_db_model
 
-    mock_create_workflow_in_db = mocker.patch("api.v1.workflows.create_workflow_in_db")
+    mock_create_workflow_in_db = mocker.patch("lib.workflow_utils.create_workflow_in_db")
     mock_create_workflow_in_db.return_value = workflow_response
 
     request = {"template_id": 1, "folder_id": folder_id, "file_ids": [1, 2]}
@@ -62,10 +62,10 @@ async def test_create_workflow_no_template(
     """Test create workflow route with no template."""
 
     mock_create_subfolder_in_db = mocker.patch(
-        "api.v1.workflows.create_subfolder_in_db"
+        "lib.workflow_utils.create_subfolder_in_db"
     )
     mock_create_subfolder_in_db.return_value = folder_db_model
-    mock_create_workflow_in_db = mocker.patch("api.v1.workflows.create_workflow_in_db")
+    mock_create_workflow_in_db = mocker.patch("lib.workflow_utils.create_workflow_in_db")
     mock_create_workflow_in_db.return_value = workflow_response
 
     folder_id = 1
@@ -90,15 +90,15 @@ async def test_create_workflow_no_template_no_files(
     """Test create workflow route with no template and no files."""
     folder_id = 1
     mock_get_workflow_template_from_db = mocker.patch(
-        "api.v1.workflows.get_workflow_template_from_db"
+        "lib.workflow_utils.get_workflow_template_from_db"
     )
     mock_get_workflow_template_from_db.return_value = workflow_schema_mock
     mock_create_subfolder_in_db = mocker.patch(
-        "api.v1.workflows.create_subfolder_in_db"
+        "lib.workflow_utils.create_subfolder_in_db"
     )
     mock_create_subfolder_in_db.return_value = folder_db_model
 
-    mock_create_workflow_in_db = mocker.patch("api.v1.workflows.create_workflow_in_db")
+    mock_create_workflow_in_db = mocker.patch("lib.workflow_utils.create_workflow_in_db")
     mock_create_workflow_in_db.return_value = workflow_response
     folder_id = 1
     request = {"folder_id": folder_id}
@@ -214,7 +214,7 @@ async def test_run_workflow(
     )
     mock_get_workflow_from_db = mocker.patch("api.v1.workflows.get_workflow_from_db")
     mock_get_workflow_from_db.return_value = workflow_db_model
-    mock_create_workflow = mocker.patch("api.v1.workflows.create_workflow_signature")
+    mock_create_workflow = mocker.patch("lib.workflow_utils.create_workflow_signature")
     mock_create_workflow.return_value.apply_async.return_value = mocker.ANY
     mock_makedirs = mocker.patch("os.makedirs")
     mocker.patch("os.path.exists", return_value=False)  # Path doesn't exist
@@ -271,7 +271,7 @@ async def test_run_workflow_nested_tasks(
     )
     mock_get_workflow_from_db = mocker.patch("api.v1.workflows.get_workflow_from_db")
     mock_get_workflow_from_db.return_value = workflow_db_model
-    mock_create_workflow = mocker.patch("api.v1.workflows.create_workflow_signature")
+    mock_create_workflow = mocker.patch("lib.workflow_utils.create_workflow_signature")
     mock_create_workflow.return_value.apply_async.return_value = mocker.ANY
     mock_makedirs = mocker.patch("os.makedirs")
     mocker.patch("os.path.exists", return_value=False)  # Path doesn't exist
@@ -462,7 +462,7 @@ def test_create_workflow_signature_invalid_type(
     input_files = []
     output_path = ""
     with pytest.raises(ValueError):
-        from api.v1.workflows import create_workflow_signature
+        from lib.workflow_utils import create_workflow_signature
 
         create_workflow_signature(
             db, regular_user, task_data, input_files, output_path, workflow_schema_mock
@@ -471,7 +471,7 @@ def test_create_workflow_signature_invalid_type(
 
 def test_replace_uuids_dict(mocker):
     data = {"uuid": "old_uuid", "nested": {"uuid": "nested_old_uuid"}}
-    from api.v1.workflows import replace_uuids
+    from lib.workflow_utils import replace_uuids
 
     replace_uuids(data)
 
@@ -483,7 +483,7 @@ def test_replace_uuids_dict(mocker):
 
 def test_replace_uuids_list(mocker):
     data = [{"uuid": "old_uuid"}, {"uuid": "another_old_uuid"}]
-    from api.v1.workflows import replace_uuids
+    from lib.workflow_utils import replace_uuids
 
     replace_uuids(data)
     assert data[0]["uuid"] != "old_uuid"
@@ -497,7 +497,7 @@ def test_replace_uuids_replace_with(mocker):
     data = {"uuid": "old_uuid"}
     replace_value = "new_uuid"
 
-    from api.v1.workflows import replace_uuids
+    from lib.workflow_utils import replace_uuids
 
     replace_uuids(data, replace_with=replace_value)
     assert data["uuid"] == replace_value
@@ -508,7 +508,7 @@ def test_get_task_signature(
 ):
     """Test get_task_signature function."""
 
-    mock_create_task_in_db = mocker.patch("api.v1.workflows.create_task_in_db")
+    mock_create_task_in_db = mocker.patch("lib.workflow_utils.create_task_in_db")
     mock_create_task_in_db.return_value = task_response
     task_data = {
         "task_name": "test_task",
@@ -519,7 +519,7 @@ def test_get_task_signature(
     input_files = []
     output_path = "/tmp/output"
 
-    from api.v1.workflows import get_task_signature
+    from lib.workflow_utils import get_task_signature
 
     task_signature = get_task_signature(
         db, user_db_model, task_data, input_files, output_path, workflow_db_model
@@ -560,13 +560,13 @@ def test_create_workflow_signature_chain_multiple(
     input_files = []
     output_path = ""
 
-    mock_get_task_signature = mocker.patch("api.v1.workflows.get_task_signature")
+    mock_get_task_signature = mocker.patch("lib.workflow_utils.get_task_signature")
     mock_get_task_signature.return_value = mocker.MagicMock(spec=Signature)
 
     # Mock celery_group to consume the generator
-    mocker.patch("api.v1.workflows.celery_group", side_effect=lambda x: list(x))
+    mocker.patch("lib.workflow_utils.celery_group", side_effect=lambda x: list(x))
 
-    from api.v1.workflows import create_workflow_signature
+    from lib.workflow_utils import create_workflow_signature
 
     sig = create_workflow_signature(
         db,
@@ -607,10 +607,10 @@ def test_create_workflow_signature_chord(
     input_files = []
     output_path = ""
 
-    mock_get_task_signature = mocker.patch("api.v1.workflows.get_task_signature")
+    mock_get_task_signature = mocker.patch("lib.workflow_utils.get_task_signature")
     mock_get_task_signature.return_value = mocker.MagicMock(spec=Signature)
 
-    from api.v1.workflows import create_workflow_signature
+    from lib.workflow_utils import create_workflow_signature
 
     sig = create_workflow_signature(
         db,

--- a/src/tests/datastores/workflow_test.py
+++ b/src/tests/datastores/workflow_test.py
@@ -258,7 +258,7 @@ def test_create_task_report_in_db(mocker):
 def test_get_workflow_templates_from_db(mocker):
     """Test get_workflow_templates_from_db."""
     mock_add_unique_params = mocker.patch(
-        "datastores.sql.crud.workflow.workflow_utils.add_unique_parameter_names"
+        "datastores.sql.crud.workflow.add_unique_parameter_names"
     )
     mock_db = mocker.MagicMock()
 

--- a/src/tests/lib/workflow_spec_utils_test.py
+++ b/src/tests/lib/workflow_spec_utils_test.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.workflow_spec_utils import add_unique_parameter_names
+
+
+def test_add_unique_parameter_names():
+    """Test add_unique_parameter_names generates unique names."""
+    data = {
+        "task_config": [
+            {"name": "Parameter One"},
+            {"name": "Parameter One"},
+            {"name": "Parameter Two"},
+        ],
+        "sub_item": {
+            "task_config": [
+                {"name": "Parameter One"},
+            ]
+        },
+    }
+
+    add_unique_parameter_names(data)
+
+    assert data["task_config"][0]["param_name"] == "parameter_one_0"
+    assert data["task_config"][1]["param_name"] == "parameter_one_1"
+    assert data["task_config"][2]["param_name"] == "parameter_two_0"
+    assert data["sub_item"]["task_config"][0]["param_name"] == "parameter_one_2"
+
+
+def test_add_unique_parameter_names_no_name():
+    """Test add_unique_parameter_names ignores items without name."""
+    data = {
+        "task_config": [
+            {"value": "only value"},
+        ]
+    }
+
+    add_unique_parameter_names(data)
+
+    assert "param_name" not in data["task_config"][0]

--- a/src/tests/lib/workflow_utils_test.py
+++ b/src/tests/lib/workflow_utils_test.py
@@ -19,7 +19,7 @@ from unittest import mock
 
 from lib.workflow_utils import (
     TemplateNotFoundError,
-    create_workflow_from_template,
+    create_workflow,
     replace_uuids,
     run_workflow,
     update_task_config_values,
@@ -90,7 +90,7 @@ def _make_user(user_id=42):
     return user
 
 
-def test_create_workflow_from_template_with_template(mocker):
+def test_create_workflow_with_template(mocker):
     mock_template = mock.Mock()
     mock_template.id = 7
     mock_template.display_name = "My Template"
@@ -113,7 +113,7 @@ def test_create_workflow_from_template_with_template(mocker):
         "lib.workflow_utils.create_workflow_in_db", return_value=mock_workflow
     )
 
-    result = create_workflow_from_template(
+    result = create_workflow(
         db=mock.Mock(),
         folder_id=3,
         file_ids=[1, 2],
@@ -133,7 +133,7 @@ def test_create_workflow_from_template_with_template(mocker):
     assert created_schema.display_name == "My Template"
 
 
-def test_create_workflow_from_template_without_template(mocker):
+def test_create_workflow_without_template(mocker):
     mock_folder = mock.Mock(id=99)
     mock_workflow = mock.Mock()
     mocker.patch("lib.workflow_utils.create_subfolder_in_db", return_value=mock_folder)
@@ -141,7 +141,7 @@ def test_create_workflow_from_template_without_template(mocker):
         "lib.workflow_utils.create_workflow_in_db", return_value=mock_workflow
     )
 
-    result = create_workflow_from_template(
+    result = create_workflow(
         db=mock.Mock(),
         folder_id=3,
         file_ids=[],
@@ -156,10 +156,10 @@ def test_create_workflow_from_template_without_template(mocker):
     assert created_schema.template_id is None
 
 
-def test_create_workflow_from_template_raises_when_template_missing(mocker):
+def test_create_workflow_raises_when_template_missing(mocker):
     mocker.patch("lib.workflow_utils.get_workflow_template_from_db", return_value=None)
     with pytest.raises(TemplateNotFoundError):
-        create_workflow_from_template(
+        create_workflow(
             db=mock.Mock(),
             folder_id=3,
             file_ids=[],

--- a/src/tests/lib/workflow_utils_test.py
+++ b/src/tests/lib/workflow_utils_test.py
@@ -13,8 +13,18 @@
 # limitations under the License.
 
 import pytest
+import json
+
+from unittest import mock
+
 from lib.workflow_spec_utils import add_unique_parameter_names
-from lib.workflow_utils import update_task_config_values
+from lib.workflow_utils import (
+    TemplateNotFoundError,
+    create_workflow_from_template,
+    replace_uuids,
+    run_workflow,
+    update_task_config_values,
+)
 
 
 def test_update_task_config_values():
@@ -97,22 +107,6 @@ def test_add_unique_parameter_names_no_name():
     assert "param_name" not in data["task_config"][0]
 
 
-# ---------------------------------------------------------------------------
-# Tests for replace_uuids, create_workflow_from_template, run_workflow.
-# ---------------------------------------------------------------------------
-
-import json
-from unittest import mock
-
-from lib import workflow_utils
-from lib.workflow_utils import (
-    TemplateNotFoundError,
-    create_workflow_from_template,
-    replace_uuids,
-    run_workflow,
-)
-
-
 def test_replace_uuids_generates_fresh_uuids():
     data = {"uuid": "OLD", "inner": {"uuid": "OLD"}, "list": [{"uuid": "OLD"}]}
     replace_uuids(data)
@@ -122,10 +116,6 @@ def test_replace_uuids_generates_fresh_uuids():
 
 
 def test_replace_uuids_with_explicit_value():
-    # Note: replace_uuids does not forward `replace_with` when it recurses
-    # (pre-existing behavior on main — not addressed in this refactor). So
-    # only the top-level "uuid" picks up the placeholder; nested uuids get
-    # fresh values instead. This test pins that current behavior.
     data = {"uuid": "OLD", "inner": {"uuid": "OLD"}}
     replace_uuids(data, replace_with="PLACEHOLDER")
     assert data["uuid"] == "PLACEHOLDER"
@@ -142,7 +132,10 @@ def test_create_workflow_from_template_with_template(mocker):
     mock_template.id = 7
     mock_template.display_name = "My Template"
     mock_template.spec_json = json.dumps(
-        {"uuid": "SEED", "workflow": {"task_config": [{"param_name": "p", "value": None}]}}
+        {
+            "uuid": "SEED",
+            "workflow": {"task_config": [{"param_name": "p", "value": None}]},
+        }
     )
     mock_folder = mock.Mock(id=99)
     mock_workflow = mock.Mock()
@@ -201,9 +194,7 @@ def test_create_workflow_from_template_without_template(mocker):
 
 
 def test_create_workflow_from_template_raises_when_template_missing(mocker):
-    mocker.patch(
-        "lib.workflow_utils.get_workflow_template_from_db", return_value=None
-    )
+    mocker.patch("lib.workflow_utils.get_workflow_template_from_db", return_value=None)
     with pytest.raises(TemplateNotFoundError):
         create_workflow_from_template(
             db=mock.Mock(),

--- a/src/tests/lib/workflow_utils_test.py
+++ b/src/tests/lib/workflow_utils_test.py
@@ -17,7 +17,6 @@ import json
 
 from unittest import mock
 
-from lib.workflow_spec_utils import add_unique_parameter_names
 from lib.workflow_utils import (
     TemplateNotFoundError,
     create_workflow_from_template,
@@ -69,42 +68,6 @@ def test_update_task_config_values_list():
 
     assert data[0]["task_config"][0]["value"] == "new"
     assert data[1]["task_config"][0]["value"] == "new"
-
-
-def test_add_unique_parameter_names():
-    """Test add_unique_parameter_names generates unique names."""
-    data = {
-        "task_config": [
-            {"name": "Parameter One"},
-            {"name": "Parameter One"},
-            {"name": "Parameter Two"},
-        ],
-        "sub_item": {
-            "task_config": [
-                {"name": "Parameter One"},
-            ]
-        },
-    }
-
-    add_unique_parameter_names(data)
-
-    assert data["task_config"][0]["param_name"] == "parameter_one_0"
-    assert data["task_config"][1]["param_name"] == "parameter_one_1"
-    assert data["task_config"][2]["param_name"] == "parameter_two_0"
-    assert data["sub_item"]["task_config"][0]["param_name"] == "parameter_one_2"
-
-
-def test_add_unique_parameter_names_no_name():
-    """Test add_unique_parameter_names ignores items without name."""
-    data = {
-        "task_config": [
-            {"value": "only value"},
-        ]
-    }
-
-    add_unique_parameter_names(data)
-
-    assert "param_name" not in data["task_config"][0]
 
 
 def test_replace_uuids_generates_fresh_uuids():

--- a/src/tests/lib/workflow_utils_test.py
+++ b/src/tests/lib/workflow_utils_test.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import pytest
-from lib.workflow_utils import update_task_config_values, add_unique_parameter_names
+from lib.workflow_spec_utils import add_unique_parameter_names
+from lib.workflow_utils import update_task_config_values
 
 
 def test_update_task_config_values():
@@ -94,3 +95,157 @@ def test_add_unique_parameter_names_no_name():
     add_unique_parameter_names(data)
 
     assert "param_name" not in data["task_config"][0]
+
+
+# ---------------------------------------------------------------------------
+# Tests for replace_uuids, create_workflow_from_template, run_workflow.
+# ---------------------------------------------------------------------------
+
+import json
+from unittest import mock
+
+from lib import workflow_utils
+from lib.workflow_utils import (
+    TemplateNotFoundError,
+    create_workflow_from_template,
+    replace_uuids,
+    run_workflow,
+)
+
+
+def test_replace_uuids_generates_fresh_uuids():
+    data = {"uuid": "OLD", "inner": {"uuid": "OLD"}, "list": [{"uuid": "OLD"}]}
+    replace_uuids(data)
+    assert data["uuid"] != "OLD"
+    assert data["inner"]["uuid"] != "OLD"
+    assert data["list"][0]["uuid"] != "OLD"
+
+
+def test_replace_uuids_with_explicit_value():
+    # Note: replace_uuids does not forward `replace_with` when it recurses
+    # (pre-existing behavior on main — not addressed in this refactor). So
+    # only the top-level "uuid" picks up the placeholder; nested uuids get
+    # fresh values instead. This test pins that current behavior.
+    data = {"uuid": "OLD", "inner": {"uuid": "OLD"}}
+    replace_uuids(data, replace_with="PLACEHOLDER")
+    assert data["uuid"] == "PLACEHOLDER"
+
+
+def _make_user(user_id=42):
+    user = mock.Mock()
+    user.id = user_id
+    return user
+
+
+def test_create_workflow_from_template_with_template(mocker):
+    mock_template = mock.Mock()
+    mock_template.id = 7
+    mock_template.display_name = "My Template"
+    mock_template.spec_json = json.dumps(
+        {"uuid": "SEED", "workflow": {"task_config": [{"param_name": "p", "value": None}]}}
+    )
+    mock_folder = mock.Mock(id=99)
+    mock_workflow = mock.Mock()
+
+    mocker.patch(
+        "lib.workflow_utils.get_workflow_template_from_db", return_value=mock_template
+    )
+    mock_create_folder = mocker.patch(
+        "lib.workflow_utils.create_subfolder_in_db", return_value=mock_folder
+    )
+    mock_create_workflow = mocker.patch(
+        "lib.workflow_utils.create_workflow_in_db", return_value=mock_workflow
+    )
+
+    result = create_workflow_from_template(
+        db=mock.Mock(),
+        folder_id=3,
+        file_ids=[1, 2],
+        template_id=7,
+        template_params={"p": "applied"},
+        user=_make_user(),
+    )
+
+    assert result is mock_workflow
+    mock_create_folder.assert_called_once()
+    created_schema = mock_create_workflow.call_args.args[1]
+    # The spec was deserialized, uuids replaced, params applied, and re-serialized.
+    rendered = json.loads(created_schema.spec_json)
+    assert rendered["uuid"] != "SEED"
+    assert rendered["workflow"]["task_config"][0]["value"] == "applied"
+    assert created_schema.template_id == 7
+    assert created_schema.display_name == "My Template"
+
+
+def test_create_workflow_from_template_without_template(mocker):
+    mock_folder = mock.Mock(id=99)
+    mock_workflow = mock.Mock()
+    mocker.patch("lib.workflow_utils.create_subfolder_in_db", return_value=mock_folder)
+    mock_create_workflow = mocker.patch(
+        "lib.workflow_utils.create_workflow_in_db", return_value=mock_workflow
+    )
+
+    result = create_workflow_from_template(
+        db=mock.Mock(),
+        folder_id=3,
+        file_ids=[],
+        template_id=None,
+        template_params=None,
+        user=_make_user(),
+    )
+    assert result is mock_workflow
+    created_schema = mock_create_workflow.call_args.args[1]
+    assert created_schema.display_name == "Untitled workflow"
+    assert created_schema.spec_json is None
+    assert created_schema.template_id is None
+
+
+def test_create_workflow_from_template_raises_when_template_missing(mocker):
+    mocker.patch(
+        "lib.workflow_utils.get_workflow_template_from_db", return_value=None
+    )
+    with pytest.raises(TemplateNotFoundError):
+        create_workflow_from_template(
+            db=mock.Mock(),
+            folder_id=3,
+            file_ids=[],
+            template_id=999,
+            template_params=None,
+            user=_make_user(),
+        )
+
+
+def test_run_workflow_persists_spec_and_dispatches(mocker, tmp_path):
+    fake_file = mock.Mock()
+    fake_file.id = 1
+    fake_file.uuid.hex = "abc"
+    fake_file.display_name = "x"
+    fake_file.extension = ".txt"
+    fake_file.data_type = "dt"
+    fake_file.magic_mime = "text/plain"
+    fake_file.path = "/tmp/x"
+
+    workflow = mock.Mock()
+    workflow.files = [fake_file]
+    workflow.folder.path = str(tmp_path / "output")  # will need to be created
+
+    mock_signature = mock.Mock()
+    mocker.patch(
+        "lib.workflow_utils.create_workflow_signature", return_value=mock_signature
+    )
+
+    spec = {"workflow": {"type": "chain", "tasks": []}}
+    db = mock.Mock()
+
+    result = run_workflow(db, workflow=workflow, workflow_spec=spec, user=_make_user())
+
+    # spec was persisted to the workflow before dispatch
+    assert workflow.spec_json == json.dumps(spec)
+    mock_signature.apply_async.assert_called_once()
+    # output directory was created on demand
+    assert (tmp_path / "output").is_dir()
+    # DB round-trip completed
+    db.add.assert_called_once_with(workflow)
+    db.commit.assert_called_once()
+    db.refresh.assert_called_once_with(workflow)
+    assert result is workflow


### PR DESCRIPTION
Moves replace_uuids, get_task_signature, create_workflow_signature, and the module-level Celery app out of api/v1/workflows.py into lib/workflow_utils.py, and adds two new public helpers:

- create_workflow_from_template(): resolve template (if any), render params, create a result subfolder, and persist the workflow row.
- run_workflow(): persist the spec, build the celery canvas, and dispatch.

The HTTP routes in api/v1/workflows.py become thin shells that delegate to these helpers. This allows callers (e.g. importer) to invoke workflows without using the REST API. @berggren this is the behavior we talked about for these changes.

Also introduces lib/workflow_spec_utils.py for pure-Python workflow spec manipulation (add_unique_parameter_names). Splitting this out of workflow_utils.py avoids a circular import between crud/workflow and lib/workflow_utils.