### PR TITLE
Add tests for main.py

### DIFF
--- a/src/tests/auth/google_test.py
+++ b/src/tests/auth/google_test.py
@@ -19,26 +19,24 @@ from starlette.responses import RedirectResponse
 from authlib.integrations.starlette_client import OAuthError
 
 # Mock config before importing google
-try:
-    from config import config
-
-    config["auth"] = {
-        "google": {
-            "client_id": "test_id",
-            "client_secret": "test_secret",
-            "allowlist": [],
-            "public_access": False,
-            "workspace_domain": False,
-            "allowed_robot_accounts": [],
-            "extra_audiences": [],
-        },
-        "jwt_cookie_refresh_expire_minutes": 60,
-        "jwt_cookie_access_expire_minutes": 15,
-    }
-except:
-    pass
+from config import config
 
 import auth.google as google_auth
+
+if "auth" not in config:
+    config["auth"] = {}
+
+config["auth"]["google"] = {
+    "client_id": "test_id",
+    "client_secret": "test_secret",
+    "allowlist": [],
+    "public_access": False,
+    "workspace_domain": False,
+    "allowed_robot_accounts": [],
+    "extra_audiences": [],
+}
+config["auth"]["jwt_cookie_refresh_expire_minutes"] = 60
+config["auth"]["jwt_cookie_access_expire_minutes"] = 15
 
 
 def test_validate_user_info_robot():

--- a/src/tests/main_test.py
+++ b/src/tests/main_test.py
@@ -1,0 +1,98 @@
+import pytest
+import sys
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import ProgrammingError
+from fastapi import FastAPI
+from datastores.sql.models.user import User
+from datastores.sql.models.group import Group
+import api.v1.schemas as schemas
+
+# Mock celery_utils before importing main to prevent network requests during tests.
+with patch("lib.celery_utils.update_task_queues"):
+    from main import populate_everyone_group, lifespan
+
+
+@pytest.mark.asyncio
+async def test_populate_everyone_group_new_group(mocker):
+    db_mock = MagicMock()
+    # get_group_by_name_from_db returns None
+    mocker.patch("main.get_group_by_name_from_db", return_value=None)
+
+    mock_group = Group(id=1, name="Everyone")
+    mocker.patch("main.create_group_in_db", return_value=mock_group)
+
+    user_mock = User(id=1)
+
+    # Mocking query chain
+    query_mock = MagicMock()
+    filter_mock = MagicMock()
+    all_mock = MagicMock()
+
+    db_mock.query.return_value = query_mock
+    query_mock.filter.return_value = filter_mock
+    filter_mock.all.return_value = [user_mock]
+
+    add_user_mock = mocker.patch("main.add_user_to_group")
+
+    await populate_everyone_group(db_mock)
+
+    add_user_mock.assert_called_once_with(db_mock, mock_group, user_mock)
+
+
+@pytest.mark.asyncio
+async def test_populate_everyone_group_existing_group(mocker):
+    db_mock = MagicMock()
+    mock_group = Group(id=1, name="Everyone")
+    mocker.patch("main.get_group_by_name_from_db", return_value=mock_group)
+
+    # Mocking query chain
+    query_mock = MagicMock()
+    filter_mock = MagicMock()
+
+    db_mock.query.return_value = query_mock
+    query_mock.filter.return_value = filter_mock
+    filter_mock.all.return_value = []
+
+    add_user_mock = mocker.patch("main.add_user_to_group")
+
+    await populate_everyone_group(db_mock)
+
+    add_user_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_success(mocker):
+    app = FastAPI()
+    db_mock = MagicMock()
+    session_local_mock = mocker.patch("main.SessionLocal", return_value=db_mock)
+    populate_mock = mocker.patch("main.populate_everyone_group")
+
+    async with lifespan(app):
+        pass
+
+    db_mock.execute.assert_called_once()
+    populate_mock.assert_called_once_with(db_mock)
+    db_mock.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_programming_error(mocker):
+    app = FastAPI()
+    db_mock = MagicMock()
+    db_mock.execute.side_effect = ProgrammingError("statement", "params", "orig")
+    session_local_mock = mocker.patch("main.SessionLocal", return_value=db_mock)
+    populate_mock = mocker.patch("main.populate_everyone_group")
+
+    async with lifespan(app):
+        pass
+
+    db_mock.execute.assert_called_once()
+    populate_mock.assert_not_called()
+    db_mock.close.assert_called_once()
+
+
+def test_app_configuration():
+    with patch("lib.celery_utils.update_task_queues"):
+        from main import app, api_v1
+    assert app is not None
+    assert api_v1 is not None

--- a/src/tests/main_test.py
+++ b/src/tests/main_test.py
@@ -1,11 +1,9 @@
 import pytest
-import sys
 from unittest.mock import MagicMock, patch
 from sqlalchemy.exc import ProgrammingError
 from fastapi import FastAPI
 from datastores.sql.models.user import User
 from datastores.sql.models.group import Group
-import api.v1.schemas as schemas
 
 # Mock celery_utils before importing main to prevent network requests during tests.
 with patch("lib.celery_utils.update_task_queues"):
@@ -26,7 +24,6 @@ async def test_populate_everyone_group_new_group(mocker):
     # Mocking query chain
     query_mock = MagicMock()
     filter_mock = MagicMock()
-    all_mock = MagicMock()
 
     db_mock.query.return_value = query_mock
     query_mock.filter.return_value = filter_mock
@@ -64,7 +61,7 @@ async def test_populate_everyone_group_existing_group(mocker):
 async def test_lifespan_success(mocker):
     app = FastAPI()
     db_mock = MagicMock()
-    session_local_mock = mocker.patch("main.SessionLocal", return_value=db_mock)
+    _ = mocker.patch("main.SessionLocal", return_value=db_mock)
     populate_mock = mocker.patch("main.populate_everyone_group")
 
     async with lifespan(app):
@@ -80,7 +77,7 @@ async def test_lifespan_programming_error(mocker):
     app = FastAPI()
     db_mock = MagicMock()
     db_mock.execute.side_effect = ProgrammingError("statement", "params", "orig")
-    session_local_mock = mocker.patch("main.SessionLocal", return_value=db_mock)
+    _ = mocker.patch("main.SessionLocal", return_value=db_mock)
     populate_mock = mocker.patch("main.populate_everyone_group")
 
     async with lifespan(app):


### PR DESCRIPTION
The change to google_tests.py is required here as during test discovery, src/tests/auth/google_test.py was being collected before src/tests/main_test.py.

In src/tests/auth/google_test.py, the file was doing a complete reassignment of the config["auth"] dictionary, which inadvertently erased the secret_session_key loaded from settings_example.toml:

When src/tests/main_test.py was later collected, it executed `from main import ...`, which imported main.py for the first time. main.py immediately tried to read `config["auth"]["secret_session_key"]` at the module level (for the SessionMiddleware), crashing with a KeyError since the key had been stripped by the prior test module.