### PR TITLE
Fix: Remove BuildKit cache mount syntax from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 
 # Install dependencies (without dev groups)
-RUN --mount=type=cache,target=/tmp/uv_cache \
-    uv sync --locked --no-dev
+RUN uv sync --locked --no-dev
 
 # The runtime image
 FROM python:3.12-slim-bookworm AS runtime

--- a/src/mediator/Dockerfile
+++ b/src/mediator/Dockerfile
@@ -15,8 +15,7 @@ WORKDIR /mediator
 COPY pyproject.toml uv.lock ./
 
 # Install dependencies (without dev groups)
-RUN --mount=type=cache,target=/tmp/uv_cache \
-    uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev
 
 # The runtime image
 FROM python:3.12-slim-bookworm AS runtime


### PR DESCRIPTION
Remove --mount=type=cache from uv sync steps to fix compatibility with build environments that do not enable BuildKit by default.