### PR TITLE
Move mediator file hashing of output files to a background Celery task

### DIFF
--- a/settings_example.toml
+++ b/settings_example.toml
@@ -50,7 +50,6 @@ mode = "rw"
 # Maximum file size (in bytes) that the background hashing worker will attempt to
 # hash. Files larger than this are skipped so we never read a very large file
 # (e.g. multi-GB disk images) into the hashing process. Defaults to 5 GB.
-# Can be overridden per deployment with the HASH_MAX_FILE_SIZE_BYTES env var.
 # max_file_size = 5368709120
 
 [datastores.sqlalchemy]

--- a/settings_example.toml
+++ b/settings_example.toml
@@ -46,6 +46,13 @@ mode = "rw"
 # path = "/path/to/read_only_storage"
 # mode = "ro"
 
+[server.hashing]
+# Maximum file size (in bytes) that the background hashing worker will attempt to
+# hash. Files larger than this are skipped so we never read a very large file
+# (e.g. multi-GB disk images) into the hashing process. Defaults to 5 GB.
+# Can be overridden per deployment with the HASH_MAX_FILE_SIZE_BYTES env var.
+# max_file_size = 5368709120
+
 [datastores.sqlalchemy]
 # Postgresql: postgresql://user:password@postgresserver/db
 database_url = "postgresql://<REPLACE_WITH_POSTGRES_USER>:<REPLACE_WITH_POSTGRES_PASSWORD>@<REPLACE_WITH_POSTGRES_SERVER>/<REPLACE_WITH_POSTGRES_DATABASE_NAME>"

--- a/src/lib/celery_utils.py
+++ b/src/lib/celery_utils.py
@@ -41,7 +41,14 @@ def get_registered_tasks(celery_instance):
             # This regular expression captures the entire dictionary using curly braces as delimiters.
             # group(0) retrieves the full match, i.e., the dictionary string.
             # ast.literal_eval() safely converts the dictionary string into an actual Python dictionary object.
-            metadata = ast.literal_eval(re.search("({.+})", task).group(0))
+            metadata_match = re.search("({.+})", task)
+            # The embedded metadata dict is what marks a task as a worker/workflow
+            # task. Internal tasks (e.g. the mediator's background hashing task) are
+            # registered without metadata; skip them so they don't appear in the task
+            # registry/UI and don't break parsing.
+            if not metadata_match:
+                continue
+            metadata = ast.literal_eval(metadata_match.group(0))
             if task_name in registered_task_names:
                 continue
 

--- a/src/lib/file_hashes.py
+++ b/src/lib/file_hashes.py
@@ -31,16 +31,12 @@ DEFAULT_HASH_MAX_FILE_SIZE_BYTES = 5 * 1024**3
 def _get_max_file_size_bytes():
     """Resolve the maximum file size (bytes) allowed for hashing.
 
-    Resolution order: ``HASH_MAX_FILE_SIZE_BYTES`` environment variable, then the
-    ``server.hashing.max_file_size`` setting, then the 5 GB default.
+    Read from the ``server.hashing.max_file_size`` setting, falling back to the
+    5 GB default.
 
     Returns:
         int: The maximum file size in bytes.
     """
-    env_value = os.getenv("HASH_MAX_FILE_SIZE_BYTES")
-    if env_value:
-        return int(env_value)
-
     configured = config.get("server", {}).get("hashing", {}).get("max_file_size")
     if configured:
         return int(configured)

--- a/src/lib/file_hashes.py
+++ b/src/lib/file_hashes.py
@@ -13,9 +13,39 @@
 # limitations under the License.
 
 import hashlib
+import logging
+import os
 
+from config import config
 from datastores.sql import database
 from datastores.sql.crud.file import get_file_from_db
+
+logger = logging.getLogger(__name__)
+
+# Default maximum size (in bytes) of a file we will attempt to hash. Files larger
+# than this are skipped so we never read a very large file (e.g. multi-GB disk
+# images served over a storage gateway) into the hashing process. Defaults to 5 GB.
+DEFAULT_HASH_MAX_FILE_SIZE_BYTES = 5 * 1024**3
+
+
+def _get_max_file_size_bytes():
+    """Resolve the maximum file size (bytes) allowed for hashing.
+
+    Resolution order: ``HASH_MAX_FILE_SIZE_BYTES`` environment variable, then the
+    ``server.hashing.max_file_size`` setting, then the 5 GB default.
+
+    Returns:
+        int: The maximum file size in bytes.
+    """
+    env_value = os.getenv("HASH_MAX_FILE_SIZE_BYTES")
+    if env_value:
+        return int(env_value)
+
+    configured = config.get("server", {}).get("hashing", {}).get("max_file_size")
+    if configured:
+        return int(configured)
+
+    return DEFAULT_HASH_MAX_FILE_SIZE_BYTES
 
 
 def _calculate_file_hashes(file_path):
@@ -54,6 +84,19 @@ def generate_hashes(file_id):
     """
     db = database.SessionLocal()
     file = get_file_from_db(db, file_id)
+
+    # Skip hashing for files larger than the configured maximum. Read the actual
+    # on-disk size, as the stored `filesize` may be unset for some files.
+    max_file_size = _get_max_file_size_bytes()
+    file_size = os.path.getsize(file.path)
+    if file_size > max_file_size:
+        logger.warning(
+            "Skipping hashing for file %s (%s bytes), exceeds maximum of %s bytes",
+            file_id,
+            file_size,
+            max_file_size,
+        )
+        return
 
     # Calculate the hashes for the file.
     md5_hash, sha1_hash, sha256_hash = _calculate_file_hashes(file.path)

--- a/src/lib/file_hashes.py
+++ b/src/lib/file_hashes.py
@@ -37,9 +37,9 @@ def _get_max_file_size_bytes():
     Returns:
         int: The maximum file size in bytes.
     """
-    configured = config.get("server", {}).get("hashing", {}).get("max_file_size")
-    if configured:
-        return int(configured)
+    max_file_size = config.get("server", {}).get("hashing", {}).get("max_file_size")
+    if max_file_size is not None:
+        return int(max_file_size)
 
     return DEFAULT_HASH_MAX_FILE_SIZE_BYTES
 

--- a/src/mediator/mediator.py
+++ b/src/mediator/mediator.py
@@ -44,8 +44,8 @@ from datastores.sql.crud.workflow import (
 )
 from datastores.sql.models.file import File
 from datastores.sql.models.workflow import Task
-from tasks.file_hashes_tasks import QUEUE_NAME as HASHING_QUEUE_NAME
-from tasks.file_hashes_tasks import TASK_NAME as HASHING_TASK_NAME
+from tasks.hashing.file_hashes_tasks import QUEUE_NAME as HASHING_QUEUE_NAME
+from tasks.hashing.file_hashes_tasks import TASK_NAME as HASHING_TASK_NAME
 
 # Number of times to retry database lookups
 MAX_DATABASE_LOOKUP_RETRIES = 10

--- a/src/mediator/mediator.py
+++ b/src/mediator/mediator.py
@@ -44,7 +44,8 @@ from datastores.sql.crud.workflow import (
 )
 from datastores.sql.models.file import File
 from datastores.sql.models.workflow import Task
-from lib.file_hashes import generate_hashes
+from tasks.file_hashes_tasks import QUEUE_NAME as HASHING_QUEUE_NAME
+from tasks.file_hashes_tasks import TASK_NAME as HASHING_TASK_NAME
 
 # Number of times to retry database lookups
 MAX_DATABASE_LOOKUP_RETRIES = 10
@@ -236,14 +237,16 @@ def process_successful_task(
         # Process any pending reports that are waiting for this file
         process_pending_file_reports(db, file_data.get("uuid"))
 
-        # TODO: Move this to a celery task to run in the background
-        generate_hashes(new_file.id)
+        # Dispatch hashing to the background worker so it does not block the
+        # mediator's sequential event loop.
+        celery_app.send_task(HASHING_TASK_NAME, args=[new_file.id], queue=HASHING_QUEUE_NAME)
 
     # Create files from task log files
     for task_file_data in task_files:
         new_log_file = create_file_in_database(db, task_file_data, result_dict, db_task)
-        # TODO: Move this to a celery task to run in the background
-        generate_hashes(new_log_file.id)
+        # Dispatch hashing to the background worker so it does not block the
+        # mediator's sequential event loop.
+        celery_app.send_task(HASHING_TASK_NAME, args=[new_log_file.id], queue=HASHING_QUEUE_NAME)
 
     for file_report in file_reports:
         create_or_defer_file_report(db, file_report, db_task.id)

--- a/src/mediator/mediator.py
+++ b/src/mediator/mediator.py
@@ -44,12 +44,19 @@ from datastores.sql.crud.workflow import (
 )
 from datastores.sql.models.file import File
 from datastores.sql.models.workflow import Task
+from lib.file_hashes import generate_hashes
 from tasks.hashing.file_hashes_tasks import QUEUE_NAME as HASHING_QUEUE_NAME
 from tasks.hashing.file_hashes_tasks import TASK_NAME as HASHING_TASK_NAME
 
 # Number of times to retry database lookups
 MAX_DATABASE_LOOKUP_RETRIES = 10
 DATABASE_LOOKUP_RETRY_DELAY_SECONDS = 1
+
+# How long to cache the openrelik-hashing worker availability check. Detecting the
+# worker requires a ~1s Celery inspect() broadcast, so we cache it to avoid running
+# that on every task event in the mediator's single-threaded loop.
+HASHING_WORKER_CHECK_TTL_SECONDS = 60
+_hashing_worker_cache = {"available": False, "checked_at": None}
 
 # A dictionary where the key is the UUID of any MISSING file needed for a file report.
 PENDING_FILE_REPORTS = {}
@@ -205,6 +212,57 @@ def process_task_progress_event(
     update_database(db, db_task)
 
 
+def is_hashing_worker_available(celery_app: Celery) -> bool:
+    """Return True if a worker is consuming the openrelik-hashing queue.
+
+    The result is cached for HASHING_WORKER_CHECK_TTL_SECONDS to avoid a ~1s
+    inspect() broadcast on every task event.
+
+    Args:
+        celery_app: The Celery application.
+
+    Returns:
+        True if the openrelik-hashing worker is available, otherwise False.
+    """
+    now = time.monotonic()
+    checked_at = _hashing_worker_cache["checked_at"]
+    if checked_at is not None and (now - checked_at) < HASHING_WORKER_CHECK_TTL_SECONDS:
+        return _hashing_worker_cache["available"]
+
+    available = False
+    try:
+        active_queues = celery_app.control.inspect().active_queues() or {}
+        available = any(
+            queue.get("name") == HASHING_QUEUE_NAME
+            for queues in active_queues.values()
+            for queue in queues
+        )
+    except Exception:
+        # Broker/inspect failure: be safe and fall back to inline hashing.
+        available = False
+
+    _hashing_worker_cache["available"] = available
+    _hashing_worker_cache["checked_at"] = now
+    return available
+
+
+def hash_file(celery_app: Celery, file_id: int) -> None:
+    """Hash a file, using the background worker when available.
+
+    Dispatches to the dedicated openrelik-hashing worker if it is available,
+    otherwise falls back to the original blocking inline hashing so that files
+    still get hashed on deployments without the hashing worker.
+
+    Args:
+        celery_app: The Celery application.
+        file_id: The ID of the file to hash.
+    """
+    if is_hashing_worker_available(celery_app):
+        celery_app.send_task(HASHING_TASK_NAME, args=[file_id], queue=HASHING_QUEUE_NAME)
+    else:
+        generate_hashes(file_id)
+
+
 def process_successful_task(
     db: Session, celery_task: CeleryEventTask, db_task: Task, celery_app: Celery
 ) -> None:
@@ -237,16 +295,16 @@ def process_successful_task(
         # Process any pending reports that are waiting for this file
         process_pending_file_reports(db, file_data.get("uuid"))
 
-        # Dispatch hashing to the background worker so it does not block the
-        # mediator's sequential event loop.
-        celery_app.send_task(HASHING_TASK_NAME, args=[new_file.id], queue=HASHING_QUEUE_NAME)
+        # Dispatch hashing to the background worker (or hash inline if it is not
+        # available) so it does not block the mediator's sequential event loop.
+        hash_file(celery_app, new_file.id)
 
     # Create files from task log files
     for task_file_data in task_files:
         new_log_file = create_file_in_database(db, task_file_data, result_dict, db_task)
-        # Dispatch hashing to the background worker so it does not block the
-        # mediator's sequential event loop.
-        celery_app.send_task(HASHING_TASK_NAME, args=[new_log_file.id], queue=HASHING_QUEUE_NAME)
+        # Dispatch hashing to the background worker (or hash inline if it is not
+        # available) so it does not block the mediator's sequential event loop.
+        hash_file(celery_app, new_log_file.id)
 
     for file_report in file_reports:
         create_or_defer_file_report(db, file_report, db_task.id)

--- a/src/mediator/mediator.py
+++ b/src/mediator/mediator.py
@@ -55,7 +55,7 @@ DATABASE_LOOKUP_RETRY_DELAY_SECONDS = 1
 # How long to cache the openrelik-hashing worker availability check. Detecting the
 # worker requires a ~1s Celery inspect() broadcast, so we cache it to avoid running
 # that on every task event in the mediator's single-threaded loop.
-HASHING_WORKER_CHECK_TTL_SECONDS = 60
+HASHING_WORKER_CHECK_TTL_SECONDS = 3600
 _hashing_worker_cache = {"available": False, "checked_at": None}
 
 # A dictionary where the key is the UUID of any MISSING file needed for a file report.
@@ -302,8 +302,6 @@ def process_successful_task(
     # Create files from task log files
     for task_file_data in task_files:
         new_log_file = create_file_in_database(db, task_file_data, result_dict, db_task)
-        # Dispatch hashing to the background worker (or hash inline if it is not
-        # available) so it does not block the mediator's sequential event loop.
         hash_file(celery_app, new_log_file.id)
 
     for file_report in file_reports:

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/tasks/file_hashes_tasks.py
+++ b/src/tasks/file_hashes_tasks.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Celery task for generating file hashes in the background.
+
+This runs in the dedicated ``openrelik-hashing`` worker (built from the server
+image) so that callers such as the mediator can offload the blocking, potentially
+long-running hashing work instead of computing hashes inline. The queue name is
+derived by the server's dynamic routing from the task name prefix
+(see ``lib/celery_utils.py``), so the task name must start with the queue name.
+"""
+
+import os
+
+from celery.app import Celery
+from openrelik_common import telemetry
+
+from lib.file_hashes import generate_hashes
+
+# The task name prefix (before the first ".") is used by the server to route the
+# task to the matching queue, so it must equal the queue the worker consumes.
+QUEUE_NAME = "openrelik-hashing"
+TASK_NAME = f"{QUEUE_NAME}.tasks.generate_hashes"
+
+REDIS_URL = os.getenv("REDIS_URL") or "redis://localhost:6379/0"
+
+celery = Celery(
+    broker=REDIS_URL,
+    backend=REDIS_URL,
+    include=["tasks.file_hashes_tasks"],
+)
+
+telemetry.instrument_celery_app(celery)
+
+
+@celery.task(name=TASK_NAME)
+def generate_hashes_task(file_id):
+    """Generate MD5, SHA1, and SHA256 hashes for a file.
+
+    Args:
+        file_id (int): The ID of the file in the database.
+    """
+    generate_hashes(file_id)

--- a/src/tasks/hashing/Dockerfile
+++ b/src/tasks/hashing/Dockerfile
@@ -1,0 +1,40 @@
+# The build image
+FROM python:3.12-slim-bookworm AS builder
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Configure uv
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_CACHE_DIR=/tmp/uv_cache
+
+WORKDIR /hashing
+
+# Copy files needed to build
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies (without dev groups)
+RUN --mount=type=cache,target=/tmp/uv_cache \
+    uv sync --frozen --no-dev
+
+# The runtime image
+FROM python:3.12-slim-bookworm AS runtime
+
+# libmagic is needed for python-magic package
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libmagic1 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set variables to point to the built virtualenv
+ENV VIRTUAL_ENV=/hashing/.venv PATH="/hashing/.venv/bin:$PATH"
+
+# Copy python virtualenv from the build step
+WORKDIR /hashing
+COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+
+# Copy needed files
+COPY src ./openrelik_server
+
+# Set workdir for the worker to function
+WORKDIR /hashing/openrelik_server

--- a/src/tasks/hashing/__init__.py
+++ b/src/tasks/hashing/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/tasks/hashing/file_hashes_tasks.py
+++ b/src/tasks/hashing/file_hashes_tasks.py
@@ -16,9 +16,9 @@
 
 This runs in the dedicated ``openrelik-hashing`` worker (built from the server
 image) so that callers such as the mediator can offload the blocking, potentially
-long-running hashing work instead of computing hashes inline. The queue name is
-derived by the server's dynamic routing from the task name prefix
-(see ``lib/celery_utils.py``), so the task name must start with the queue name.
+long-running hashing work instead of computing hashes inline. Callers dispatch the
+task with an explicit ``queue="openrelik-hashing"`` and the worker consumes that
+same queue (``-Q openrelik-hashing``).
 """
 
 import os
@@ -28,8 +28,6 @@ from openrelik_common import telemetry
 
 from lib.file_hashes import generate_hashes
 
-# The task name prefix (before the first ".") is used by the server to route the
-# task to the matching queue, so it must equal the queue the worker consumes.
 QUEUE_NAME = "openrelik-hashing"
 TASK_NAME = f"{QUEUE_NAME}.tasks.generate_hashes"
 

--- a/src/tasks/hashing/file_hashes_tasks.py
+++ b/src/tasks/hashing/file_hashes_tasks.py
@@ -38,7 +38,7 @@ REDIS_URL = os.getenv("REDIS_URL") or "redis://localhost:6379/0"
 celery = Celery(
     broker=REDIS_URL,
     backend=REDIS_URL,
-    include=["tasks.file_hashes_tasks"],
+    include=["tasks.hashing.file_hashes_tasks"],
 )
 
 telemetry.instrument_celery_app(celery)

--- a/src/tasks/hashing/file_hashes_tasks.py
+++ b/src/tasks/hashing/file_hashes_tasks.py
@@ -14,11 +14,12 @@
 
 """Celery task for generating file hashes in the background.
 
-This runs in the dedicated ``openrelik-hashing`` worker (built from the server
-image) so that callers such as the mediator can offload the blocking, potentially
-long-running hashing work instead of computing hashes inline. Callers dispatch the
-task with an explicit ``queue="openrelik-hashing"`` and the worker consumes that
-same queue (``-Q openrelik-hashing``).
+This runs in the dedicated ``openrelik-hashing`` Celery worker (built from the
+server image) so that callers such as the mediator can offload the blocking,
+potentially long-running hashing work instead of computing hashes inline.
+
+Callers dispatch the task with an explicit ``queue="openrelik-hashing"`` and the
+worker consumes that same queue (``-Q openrelik-hashing``).
 """
 
 import os

--- a/src/tests/lib/celery_utils_test.py
+++ b/src/tests/lib/celery_utils_test.py
@@ -61,6 +61,32 @@ def test_get_registered_tasks(mock_celery):
     assert tasks[1]["display_name"] == "Task 2"
 
 
+def test_get_registered_tasks_skips_tasks_without_metadata(mock_celery):
+    """Tasks without embedded metadata (e.g. the internal hashing task) are skipped.
+
+    The hashing worker shares the broker and replies to inspect().registered(), but it
+    registers its task without a metadata dict. Such tasks must be excluded rather than
+    crashing the endpoint.
+    """
+    mock_inspect = mock_celery.control.inspect.return_value
+
+    mock_inspect.registered.return_value = {
+        "worker1": [
+            "task.name.1 {'display_name': 'Task 1'}",
+        ],
+        "openrelik-hashing-worker": [
+            # No metadata dict — internal mediator-dispatched task.
+            "openrelik-hashing.tasks.generate_hashes",
+        ],
+    }
+
+    tasks = get_registered_tasks(mock_celery)
+
+    # Only the metadata-carrying worker task is returned; no exception raised.
+    assert len(tasks) == 1
+    assert tasks[0]["task_name"] == "task.name.1"
+
+
 def test_get_registered_tasks_empty(mock_celery):
     """Test get_registered_tasks when no tasks are registered."""
     mock_inspect = mock_celery.control.inspect.return_value

--- a/src/tests/lib/file_hashes_test.py
+++ b/src/tests/lib/file_hashes_test.py
@@ -83,18 +83,19 @@ def test_generate_hashes_skips_oversized_file(mocker, db):
     db.commit.assert_not_called()
 
 
-def test_get_max_file_size_bytes_from_env(mocker):
-    """The env var overrides config and the default."""
+def test_get_max_file_size_bytes_from_config(mocker):
+    """The setting is read from server.hashing.max_file_size."""
     from lib import file_hashes
 
-    mocker.patch.dict("os.environ", {"HASH_MAX_FILE_SIZE_BYTES": "12345"})
+    mocker.patch.object(
+        file_hashes, "config", {"server": {"hashing": {"max_file_size": 12345}}}
+    )
     assert file_hashes._get_max_file_size_bytes() == 12345
 
 
 def test_get_max_file_size_bytes_default(mocker):
-    """With no env var or config, the 5 GB default is used."""
+    """With no config value, the 5 GB default is used."""
     from lib import file_hashes
 
-    mocker.patch.dict("os.environ", {}, clear=True)
     mocker.patch.object(file_hashes, "config", {})
     assert file_hashes._get_max_file_size_bytes() == file_hashes.DEFAULT_HASH_MAX_FILE_SIZE_BYTES

--- a/src/tests/lib/file_hashes_test.py
+++ b/src/tests/lib/file_hashes_test.py
@@ -42,6 +42,8 @@ def test_generate_hashes(mocker, db):
     mocker.patch("lib.file_hashes.database.SessionLocal", return_value=db)
     mock_get_file = mocker.patch("lib.file_hashes.get_file_from_db")
     mock_calc_hashes = mocker.patch("lib.file_hashes._calculate_file_hashes")
+    # File is well under the size limit.
+    mocker.patch("lib.file_hashes.os.path.getsize", return_value=1024)
 
     mock_file = mocker.MagicMock()
     mock_file.path = "/dummy/path"
@@ -59,3 +61,40 @@ def test_generate_hashes(mocker, db):
     assert mock_file.hash_sha256 == "sha256sum"
 
     db.commit.assert_called_once()
+
+
+def test_generate_hashes_skips_oversized_file(mocker, db):
+    """Files larger than the max size are skipped without hashing or errors."""
+    mocker.patch("lib.file_hashes.database.SessionLocal", return_value=db)
+    mock_get_file = mocker.patch("lib.file_hashes.get_file_from_db")
+    mock_calc_hashes = mocker.patch("lib.file_hashes._calculate_file_hashes")
+    mocker.patch("lib.file_hashes._get_max_file_size_bytes", return_value=1024)
+    # File is larger than the (mocked) 1 KB limit.
+    mocker.patch("lib.file_hashes.os.path.getsize", return_value=2048)
+
+    mock_file = mocker.MagicMock()
+    mock_file.path = "/dummy/path"
+    mock_get_file.return_value = mock_file
+
+    generate_hashes(file_id=1)
+
+    # Hashing must not run, and no hashes committed.
+    mock_calc_hashes.assert_not_called()
+    db.commit.assert_not_called()
+
+
+def test_get_max_file_size_bytes_from_env(mocker):
+    """The env var overrides config and the default."""
+    from lib import file_hashes
+
+    mocker.patch.dict("os.environ", {"HASH_MAX_FILE_SIZE_BYTES": "12345"})
+    assert file_hashes._get_max_file_size_bytes() == 12345
+
+
+def test_get_max_file_size_bytes_default(mocker):
+    """With no env var or config, the 5 GB default is used."""
+    from lib import file_hashes
+
+    mocker.patch.dict("os.environ", {}, clear=True)
+    mocker.patch.object(file_hashes, "config", {})
+    assert file_hashes._get_max_file_size_bytes() == file_hashes.DEFAULT_HASH_MAX_FILE_SIZE_BYTES

--- a/src/tests/mediator/test_mediator.py
+++ b/src/tests/mediator/test_mediator.py
@@ -51,6 +51,9 @@ def fake_dependencies(monkeypatch):
     )
     monkeypatch.setattr(mediator, "process_pending_file_reports", mock.Mock())
     monkeypatch.setattr(mediator, "create_task_report_in_db", mock.Mock())
+    # Stub hashing so tests that don't exercise it never touch the real DB or
+    # broker. Tests that assert on hashing behavior override these.
+    monkeypatch.setattr(mediator, "generate_hashes", mock.Mock())
 
     return created
 
@@ -281,8 +284,20 @@ def test_create_or_defer_file_report_deferred(monkeypatch):
     assert mediator.PENDING_FILE_REPORTS["uuid-2"] == [(file_report, 123)]
 
 
-def test_hashing_is_dispatched_as_background_task(monkeypatch, fake_dependencies):
-    """Hashing must be dispatched to the background queue, not run inline."""
+@pytest.fixture(autouse=True)
+def _reset_hashing_worker_cache():
+    """Clear the cached hashing-worker availability between tests."""
+    mediator._hashing_worker_cache["available"] = False
+    mediator._hashing_worker_cache["checked_at"] = None
+    yield
+
+
+def test_hashing_is_dispatched_when_worker_available(monkeypatch, fake_dependencies):
+    """When the hashing worker is available, hashing is dispatched, not run inline."""
+    monkeypatch.setattr(mediator, "is_hashing_worker_available", lambda celery_app: True)
+    mock_generate_hashes = mock.Mock()
+    monkeypatch.setattr(mediator, "generate_hashes", mock_generate_hashes)
+
     output_files = [{"uuid": "a", "register_in_db": True}]
     task_files = [{"uuid": "log"}]
 
@@ -298,3 +313,62 @@ def test_hashing_is_dispatched_as_background_task(monkeypatch, fake_dependencies
     for call in celery_app.send_task.call_args_list:
         assert call.args[0] == mediator.HASHING_TASK_NAME
         assert call.kwargs["queue"] == mediator.HASHING_QUEUE_NAME
+    # Nothing hashed inline.
+    mock_generate_hashes.assert_not_called()
+
+
+def test_hashing_falls_back_to_inline_when_worker_unavailable(monkeypatch, fake_dependencies):
+    """Without the hashing worker, hashing runs inline (backwards compatible)."""
+    monkeypatch.setattr(mediator, "is_hashing_worker_available", lambda celery_app: False)
+    mock_generate_hashes = mock.Mock()
+    monkeypatch.setattr(mediator, "generate_hashes", mock_generate_hashes)
+
+    output_files = [{"uuid": "a", "register_in_db": True}]
+    task_files = [{"uuid": "log"}]
+
+    celery_app = _run_process_successful_task(
+        monkeypatch, _encoded_result(output_files, task_files=task_files)
+    )
+
+    # Hashed inline for the output file (id 1) and the log file (id 2).
+    assert [c.args[0] for c in mock_generate_hashes.call_args_list] == [1, 2]
+    # Nothing dispatched to the background worker.
+    celery_app.send_task.assert_not_called()
+
+
+def test_is_hashing_worker_available_detects_queue(monkeypatch):
+    """Returns True when a worker consumes the hashing queue, False otherwise."""
+    celery_app = mock.Mock()
+    inspect = celery_app.control.inspect.return_value
+
+    inspect.active_queues.return_value = {
+        "celery@hasher": [{"name": mediator.HASHING_QUEUE_NAME}],
+    }
+    assert mediator.is_hashing_worker_available(celery_app) is True
+
+    # Reset cache so the next check actually re-inspects.
+    mediator._hashing_worker_cache["checked_at"] = None
+    inspect.active_queues.return_value = {"celery@other": [{"name": "some-other-queue"}]}
+    assert mediator.is_hashing_worker_available(celery_app) is False
+
+
+def test_is_hashing_worker_available_uses_cache(monkeypatch):
+    """A cached result within the TTL avoids a second inspect() broadcast."""
+    celery_app = mock.Mock()
+    inspect = celery_app.control.inspect.return_value
+    inspect.active_queues.return_value = {
+        "celery@hasher": [{"name": mediator.HASHING_QUEUE_NAME}],
+    }
+
+    assert mediator.is_hashing_worker_available(celery_app) is True
+    # Second call within TTL should not inspect again.
+    assert mediator.is_hashing_worker_available(celery_app) is True
+    inspect.active_queues.assert_called_once()
+
+
+def test_is_hashing_worker_available_handles_inspect_failure(monkeypatch):
+    """If inspect() raises, availability is False (fall back to inline hashing)."""
+    celery_app = mock.Mock()
+    celery_app.control.inspect.return_value.active_queues.side_effect = Exception("boom")
+
+    assert mediator.is_hashing_worker_available(celery_app) is False

--- a/src/tests/mediator/test_mediator.py
+++ b/src/tests/mediator/test_mediator.py
@@ -50,23 +50,28 @@ def fake_dependencies(monkeypatch):
         mediator, "create_file_in_database", _fake_create_file_in_database
     )
     monkeypatch.setattr(mediator, "process_pending_file_reports", mock.Mock())
-    monkeypatch.setattr(mediator, "generate_hashes", mock.Mock())
     monkeypatch.setattr(mediator, "create_task_report_in_db", mock.Mock())
 
     return created
 
 
 def _run_process_successful_task(monkeypatch, encoded_result):
-    """Invoke process_successful_task with the given encoded Celery result."""
+    """Invoke process_successful_task with the given encoded Celery result.
+
+    Returns:
+        The mock Celery app so callers can assert on task dispatch.
+    """
     mock_async_result = mock.Mock()
     mock_async_result.get.return_value = encoded_result
     monkeypatch.setattr(mediator, "AsyncResult", lambda *a, **kw: mock_async_result)
 
     celery_task = mock.Mock(uuid="task-uuid")
     db_task = mock.Mock()
+    celery_app = mock.Mock()
     mediator.process_successful_task(
-        db=mock.Mock(), celery_task=celery_task, db_task=db_task, celery_app=mock.Mock()
+        db=mock.Mock(), celery_task=celery_task, db_task=db_task, celery_app=celery_app
     )
+    return celery_app
 
 
 def test_output_file_with_register_in_db_false_is_skipped(
@@ -274,3 +279,22 @@ def test_create_or_defer_file_report_deferred(monkeypatch):
 
     assert mediator.PENDING_FILE_REPORTS["uuid-1"] == [(file_report, 123)]
     assert mediator.PENDING_FILE_REPORTS["uuid-2"] == [(file_report, 123)]
+
+
+def test_hashing_is_dispatched_as_background_task(monkeypatch, fake_dependencies):
+    """Hashing must be dispatched to the background queue, not run inline."""
+    output_files = [{"uuid": "a", "register_in_db": True}]
+    task_files = [{"uuid": "log"}]
+
+    celery_app = _run_process_successful_task(
+        monkeypatch, _encoded_result(output_files, task_files=task_files)
+    )
+
+    # One dispatch for the output file (id 1) and one for the log file (id 2).
+    # File ids come from the fake_dependencies fixture (len(created)).
+    assert celery_app.send_task.call_count == 2
+    dispatched_ids = [call.kwargs["args"][0] for call in celery_app.send_task.call_args_list]
+    assert dispatched_ids == [1, 2]
+    for call in celery_app.send_task.call_args_list:
+        assert call.args[0] == mediator.HASHING_TASK_NAME
+        assert call.kwargs["queue"] == mediator.HASHING_QUEUE_NAME

--- a/src/tests/tasks/file_hashes_tasks_test.py
+++ b/src/tests/tasks/file_hashes_tasks_test.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the background file hashing Celery task."""
+
+from tasks import file_hashes_tasks
+
+
+def test_generate_hashes_task_delegates(mocker):
+    """The task delegates to lib.file_hashes.generate_hashes with the file id."""
+    mock_generate_hashes = mocker.patch("tasks.file_hashes_tasks.generate_hashes")
+
+    file_hashes_tasks.generate_hashes_task(42)
+
+    mock_generate_hashes.assert_called_once_with(42)
+
+
+def test_task_name_prefix_matches_queue():
+    """Routing relies on the task name prefix equalling the queue name."""
+    assert file_hashes_tasks.TASK_NAME.split(".")[0] == file_hashes_tasks.QUEUE_NAME

--- a/src/tests/tasks/hashing/file_hashes_tasks_test.py
+++ b/src/tests/tasks/hashing/file_hashes_tasks_test.py
@@ -14,12 +14,12 @@
 
 """Tests for the background file hashing Celery task."""
 
-from tasks import file_hashes_tasks
+from tasks.hashing import file_hashes_tasks
 
 
 def test_generate_hashes_task_delegates(mocker):
     """The task delegates to lib.file_hashes.generate_hashes with the file id."""
-    mock_generate_hashes = mocker.patch("tasks.file_hashes_tasks.generate_hashes")
+    mock_generate_hashes = mocker.patch("tasks.hashing.file_hashes_tasks.generate_hashes")
 
     file_hashes_tasks.generate_hashes_task(42)
 


### PR DESCRIPTION
Hashing is moved off the mediator's event loop into a dedicated background Celery worker.

**1. New hashing task + worker** (`src/tasks/hashing/file_hashes_tasks.py`)
- A `generate_hashes_task(file_id)` Celery task that reuses the existing `lib.file_hashes.generate_hashes` (unchanged logic; it already opens its own DB session).
- Runs in a new **`openrelik-hashing`** container built from the server source (it needs server code + DB access + the shared volume). New `src/tasks/hashing/Dockerfile`, modeled on the mediator's uv-based image.

**2. Mediator dispatches instead of hashing inline** (`src/mediator/mediator.py`)
- The two blocking `generate_hashes(...)` calls in `process_successful_task` are replaced with `celery_app.send_task(TASK_NAME, args=[file_id], queue="openrelik-hashing")`. Dispatch is by name with an **explicit queue**, so the mediator doesn't import the task's runtime deps and doesn't depend on auto-routing.

**3. Configurable max file size** (`src/lib/file_hashes.py`)
- `generate_hashes` now skips files larger than a configurable ceiling (default **5 GB**), read from `server.hashing.max_file_size` in settings.toml. Prevents pulling very large files into the hashing process. Skips are logged (via `logging`, not `print`) and don't raise, so one oversized file never errors the task. Documented in `settings_example.toml`.

**4. Keep the internal task out of the worker task registry** (`src/lib/celery_utils.py`)
- The `openrelik-hashing` worker shares the broker, so it replies to `inspect().registered()`. `get_registered_tasks` assumed every task carries an embedded metadata dict but hashing is an internal task without metadata and should not appear in the registry, UI. So, openrelik-hashing task will be skipped from `get_registered_tasks`.
