### PR TITLE
Remove BuildKit cache mount syntax from Dockerfiles

### DIFF
--- a/src/importers/gcp/Dockerfile
+++ b/src/importers/gcp/Dockerfile
@@ -15,8 +15,7 @@ WORKDIR /importers/gcp
 COPY pyproject.toml uv.lock ./
 
 # Install dependencies (without dev groups)
-RUN --mount=type=cache,target=/tmp/uv_cache \
-    uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev
 
 # The runtime image
 FROM python:3.12-slim-bookworm AS runtime


### PR DESCRIPTION
Similar to https://github.com/openrelik/openrelik-server/pull/212 but for the importer container