### PR TITLE
Fix against arbitrary Celery task dispatch via user-supplied task_name and queue_name in workflow spec

### DIFF
--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -90,7 +90,28 @@ def get_task_signature(
     Returns:
         Signature: The Celery task signature.
     """
-    task_uuid = task_data.get("uuid", uuid4().hex)
+    from lib.celery_utils import get_registered_tasks
+    import kombu.exceptions
+
+    try:
+        valid_tasks = get_registered_tasks(celery_app)
+    except kombu.exceptions.OperationalError:
+        valid_tasks = []
+        
+    task_name = task_data.get("task_name")
+    
+    task_info = None
+    for task in valid_tasks:
+        if task.get("task_name") == task_name:
+            task_info = task
+            break
+    if not task_info:
+        raise ValueError(f"Task name {task_name} is not allowed or not registered.")
+    
+    task_uuid = uuid4().hex
+    task_data["uuid"] = task_uuid
+    queue_name = task_info.get("queue_name")
+
     task_config = {
         option["name"]: option.get("value")
         for option in task_data.get("task_config", {})
@@ -109,14 +130,14 @@ def get_task_signature(
     create_task_in_db(db, new_task_db)
 
     task_signature = signature(
-        task_data.get("task_name"),
+        task_name,
         kwargs={
             "input_files": input_files,
             "output_path": output_path,
             "workflow_id": workflow.id,
             "task_config": task_config,
         },
-        queue=task_data.get("queue_name"),
+        queue=queue_name,
         task_id=task_uuid,
     )
     return task_signature

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -25,6 +25,7 @@ from celery import group as celery_group
 from celery import signature
 from celery.app import Celery
 from celery.canvas import Signature
+import kombu.exceptions
 from sqlalchemy.orm import Session
 
 from api.v1 import schemas
@@ -35,6 +36,7 @@ from datastores.sql.crud.workflow import (
     get_workflow_template_from_db,
 )
 from datastores.sql.models.workflow import Task, Workflow
+from lib.celery_utils import get_registered_tasks
 
 # Redis URL and Celery app initialization.
 _redis_url = os.getenv("REDIS_URL")
@@ -90,8 +92,6 @@ def get_task_signature(
     Returns:
         Signature: The Celery task signature.
     """
-    from lib.celery_utils import get_registered_tasks
-    import kombu.exceptions
 
     try:
         valid_tasks = get_registered_tasks(celery_app)
@@ -105,6 +105,7 @@ def get_task_signature(
         if task.get("task_name") == task_name:
             task_info = task
             break
+
     if not task_info:
         raise ValueError(f"Task name {task_name} is not allowed or not registered.")
 

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -97,9 +97,9 @@ def get_task_signature(
         valid_tasks = get_registered_tasks(celery_app)
     except kombu.exceptions.OperationalError:
         valid_tasks = []
-        
+
     task_name = task_data.get("task_name")
-    
+
     task_info = None
     for task in valid_tasks:
         if task.get("task_name") == task_name:
@@ -107,7 +107,7 @@ def get_task_signature(
             break
     if not task_info:
         raise ValueError(f"Task name {task_name} is not allowed or not registered.")
-    
+
     task_uuid = uuid4().hex
     task_data["uuid"] = task_uuid
     queue_name = task_info.get("queue_name")

--- a/src/tests/api/v1/workflows_test.py
+++ b/src/tests/api/v1/workflows_test.py
@@ -24,6 +24,8 @@ from sqlalchemy.orm import Session
 from api.v1 import schemas
 from datastores.sql.models.workflow import Workflow
 
+from lib.workflow_utils import get_task_signature
+
 
 @pytest.mark.asyncio
 async def test_create_workflow(
@@ -513,12 +515,11 @@ def test_get_task_signature(
     mocker, db, user_db_model, task_response, workflow_db_model
 ):
     """Test get_task_signature function."""
-    import pytest
 
     mock_create_task_in_db = mocker.patch("lib.workflow_utils.create_task_in_db")
     mock_create_task_in_db.return_value = task_response
 
-    mock_get_registered_tasks = mocker.patch("lib.celery_utils.get_registered_tasks")
+    mock_get_registered_tasks = mocker.patch("lib.workflow_utils.get_registered_tasks")
     mock_get_registered_tasks.return_value = [
         {"task_name": "test_task", "queue_name": "server_queue"}
     ]
@@ -532,7 +533,6 @@ def test_get_task_signature(
     input_files = []
     output_path = "/tmp/output"
 
-    from lib.workflow_utils import get_task_signature
 
     task_signature = get_task_signature(
         db, user_db_model, task_data, input_files, output_path, workflow_db_model

--- a/src/tests/api/v1/workflows_test.py
+++ b/src/tests/api/v1/workflows_test.py
@@ -44,7 +44,9 @@ async def test_create_workflow(
     )
     mock_create_subfolder_in_db.return_value = folder_db_model
 
-    mock_create_workflow_in_db = mocker.patch("lib.workflow_utils.create_workflow_in_db")
+    mock_create_workflow_in_db = mocker.patch(
+        "lib.workflow_utils.create_workflow_in_db"
+    )
     mock_create_workflow_in_db.return_value = workflow_response
 
     request = {"template_id": 1, "folder_id": folder_id, "file_ids": [1, 2]}
@@ -65,7 +67,9 @@ async def test_create_workflow_no_template(
         "lib.workflow_utils.create_subfolder_in_db"
     )
     mock_create_subfolder_in_db.return_value = folder_db_model
-    mock_create_workflow_in_db = mocker.patch("lib.workflow_utils.create_workflow_in_db")
+    mock_create_workflow_in_db = mocker.patch(
+        "lib.workflow_utils.create_workflow_in_db"
+    )
     mock_create_workflow_in_db.return_value = workflow_response
 
     folder_id = 1
@@ -98,7 +102,9 @@ async def test_create_workflow_no_template_no_files(
     )
     mock_create_subfolder_in_db.return_value = folder_db_model
 
-    mock_create_workflow_in_db = mocker.patch("lib.workflow_utils.create_workflow_in_db")
+    mock_create_workflow_in_db = mocker.patch(
+        "lib.workflow_utils.create_workflow_in_db"
+    )
     mock_create_workflow_in_db.return_value = workflow_response
     folder_id = 1
     request = {"folder_id": folder_id}
@@ -511,9 +517,11 @@ def test_get_task_signature(
 
     mock_create_task_in_db = mocker.patch("lib.workflow_utils.create_task_in_db")
     mock_create_task_in_db.return_value = task_response
-    
+
     mock_get_registered_tasks = mocker.patch("lib.workflow_utils.get_registered_tasks")
-    mock_get_registered_tasks.return_value = [{"task_name": "test_task", "queue_name": "server_queue"}]
+    mock_get_registered_tasks.return_value = [
+        {"task_name": "test_task", "queue_name": "server_queue"}
+    ]
 
     task_data = {
         "task_name": "test_task",
@@ -532,7 +540,7 @@ def test_get_task_signature(
 
     assert isinstance(task_signature, Signature)
     assert task_signature.options.get("queue") == "server_queue"
-    
+
     mock_create_task_in_db.assert_called_once()
     created_task = mock_create_task_in_db.call_args[0][1]
     assert created_task.display_name is None

--- a/src/tests/api/v1/workflows_test.py
+++ b/src/tests/api/v1/workflows_test.py
@@ -518,7 +518,7 @@ def test_get_task_signature(
     mock_create_task_in_db = mocker.patch("lib.workflow_utils.create_task_in_db")
     mock_create_task_in_db.return_value = task_response
 
-    mock_get_registered_tasks = mocker.patch("lib.workflow_utils.get_registered_tasks")
+    mock_get_registered_tasks = mocker.patch("lib.celery_utils.get_registered_tasks")
     mock_get_registered_tasks.return_value = [
         {"task_name": "test_task", "queue_name": "server_queue"}
     ]

--- a/src/tests/api/v1/workflows_test.py
+++ b/src/tests/api/v1/workflows_test.py
@@ -507,9 +507,14 @@ def test_get_task_signature(
     mocker, db, user_db_model, task_response, workflow_db_model
 ):
     """Test get_task_signature function."""
+    import pytest
 
     mock_create_task_in_db = mocker.patch("lib.workflow_utils.create_task_in_db")
     mock_create_task_in_db.return_value = task_response
+    
+    mock_get_registered_tasks = mocker.patch("lib.workflow_utils.get_registered_tasks")
+    mock_get_registered_tasks.return_value = [{"task_name": "test_task", "queue_name": "server_queue"}]
+
     task_data = {
         "task_name": "test_task",
         "queue_name": "test_queue",
@@ -526,13 +531,22 @@ def test_get_task_signature(
     )
 
     assert isinstance(task_signature, Signature)
+    assert task_signature.options.get("queue") == "server_queue"
+    
     mock_create_task_in_db.assert_called_once()
     created_task = mock_create_task_in_db.call_args[0][1]
     assert created_task.display_name is None
     assert created_task.description is None
-    assert created_task.uuid == "test_uuid"
+    assert created_task.uuid != "test_uuid"
+    assert len(created_task.uuid) == 32
     assert created_task.status_short == "PENDING"
     assert json.loads(created_task.config) == {"param1": "value1"}
+
+    task_data["task_name"] = "malicious_task"
+    with pytest.raises(ValueError):
+        get_task_signature(
+            db, user_db_model, task_data, input_files, output_path, workflow_db_model
+        )
 
 
 def test_create_workflow_signature_chain_multiple(


### PR DESCRIPTION
We are fixing a situation where an authenticated user could invoke any arbitrary registered Celery tasks on arbitrary queues with any kwargs, because neither `task_name` nor `queue_name` were validated against `get_registered_tasks` or any allowlist.

also, because `task_id` was also taken from the spec (`task_data.get('uuid')`), any user could collide with / overwrite the result of another tenant's running task in the Redis backend. So we make a new one.



