### PR TITLE
workflow_utils: fix bug introduced by using server-side unique uuids

### DIFF
--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -109,11 +109,6 @@ def get_task_signature(
     if not task_info:
         raise ValueError(f"Task name {task_name} is not allowed or not registered.")
 
-    # Always generate the task/celery-task-id server-side -- task_data comes
-    # from a client-supplied workflow_spec (WorkflowRunRequest.workflow_spec
-    # has no schema/uuid validation), so trusting a caller-provided uuid here
-    # would let one tenant target another tenant's real, in-flight Celery
-    # task_id and collide with/overwrite its Redis result-backend entry.
     task_uuid = uuid4().hex
     task_data["uuid"] = task_uuid
     queue_name = task_info.get("queue_name")

--- a/src/lib/workflow_utils.py
+++ b/src/lib/workflow_utils.py
@@ -109,6 +109,11 @@ def get_task_signature(
     if not task_info:
         raise ValueError(f"Task name {task_name} is not allowed or not registered.")
 
+    # Always generate the task/celery-task-id server-side -- task_data comes
+    # from a client-supplied workflow_spec (WorkflowRunRequest.workflow_spec
+    # has no schema/uuid validation), so trusting a caller-provided uuid here
+    # would let one tenant target another tenant's real, in-flight Celery
+    # task_id and collide with/overwrite its Redis result-backend entry.
     task_uuid = uuid4().hex
     task_data["uuid"] = task_uuid
     queue_name = task_info.get("queue_name")
@@ -386,8 +391,6 @@ def run_workflow(
     Returns:
         A Workflow instance representing the workflow that was run.
     """
-    workflow.spec_json = json.dumps(workflow_spec)
-
     input_files = [
         {
             "id": file.id,
@@ -413,6 +416,13 @@ def run_workflow(
         output_path,
         workflow,
     )
+    # create_workflow_signature() (via get_task_signature()) mutates each
+    # node's "uuid" in workflow_spec in place, assigning the server-generated
+    # task_id actually dispatched to Celery. Persist spec_json only after
+    # that walk, so the DB task rows' uuids match the spec tree the frontend
+    # matches them against -- serializing before this point would persist
+    # the pre-dispatch (client-supplied) uuids instead.
+    workflow.spec_json = json.dumps(workflow_spec)
     celery_workflow.apply_async()
 
     db.add(workflow)

--- a/src/tests/api/v1/workflows_test.py
+++ b/src/tests/api/v1/workflows_test.py
@@ -528,7 +528,12 @@ def test_get_task_signature(
         "task_name": "test_task",
         "queue_name": "test_queue",
         "task_config": [{"name": "param1", "value": "value1"}],
-        "uuid": "test_uuid",
+        # A client-supplied uuid must never be trusted: task_data comes from
+        # WorkflowRunRequest.workflow_spec, an unvalidated client dict, and
+        # this value becomes the Celery task_id used as the Redis
+        # result-backend key. Trusting it would let one tenant collide with
+        # or overwrite another tenant's real, in-flight task result.
+        "uuid": "attacker-supplied-uuid",
     }
     input_files = []
     output_path = "/tmp/output"
@@ -545,10 +550,15 @@ def test_get_task_signature(
     created_task = mock_create_task_in_db.call_args[0][1]
     assert created_task.display_name is None
     assert created_task.description is None
-    assert created_task.uuid != "test_uuid"
+    # Always generated server-side, regardless of what task_data carried in.
+    assert created_task.uuid != "attacker-supplied-uuid"
     assert len(created_task.uuid) == 32
     assert created_task.status_short == "PENDING"
     assert json.loads(created_task.config) == {"param1": "value1"}
+    # The generated uuid is written back into task_data, so the caller's
+    # in-memory spec tree (and, once run_workflow() re-serializes it after
+    # dispatch) its persisted spec_json matches the DB task's uuid.
+    assert task_data["uuid"] == created_task.uuid
 
     task_data["task_name"] = "malicious_task"
     with pytest.raises(ValueError):

--- a/src/tests/lib/workflow_utils_test.py
+++ b/src/tests/lib/workflow_utils_test.py
@@ -203,3 +203,46 @@ def test_run_workflow_persists_spec_and_dispatches(mocker, tmp_path):
     db.commit.assert_called_once()
     db.refresh.assert_called_once_with(workflow)
     assert result is workflow
+
+
+def test_run_workflow_persists_spec_after_uuid_assignment(mocker, tmp_path):
+    """spec_json must reflect the uuids actually dispatched to Celery.
+
+    create_workflow_signature() (via get_task_signature()) mutates each
+    task node's "uuid" in place, assigning the server-generated task_id.
+    spec_json must be serialized AFTER that mutation -- serializing before
+    would persist the pre-dispatch uuids, permanently diverging from the
+    DB task rows' uuids and breaking the frontend's uuid-based task lookup.
+    """
+    fake_file = mock.Mock()
+    fake_file.id = 1
+    fake_file.uuid.hex = "abc"
+    fake_file.display_name = "x"
+    fake_file.extension = ".txt"
+    fake_file.data_type = "dt"
+    fake_file.magic_mime = "text/plain"
+    fake_file.path = "/tmp/x"
+
+    workflow = mock.Mock()
+    workflow.files = [fake_file]
+    workflow.folder.path = str(tmp_path / "output")
+
+    task_node = {"type": "task", "uuid": "pre-dispatch-uuid", "tasks": []}
+    spec = {"workflow": task_node}
+
+    def fake_create_workflow_signature(db, user, task_data, *args, **kwargs):
+        # Simulate get_task_signature()'s real mutation: overwrite whatever
+        # uuid was there with a freshly generated one.
+        task_data["uuid"] = "server-generated-uuid"
+        return mock.Mock()
+
+    mocker.patch(
+        "lib.workflow_utils.create_workflow_signature",
+        side_effect=fake_create_workflow_signature,
+    )
+
+    db = mock.Mock()
+    run_workflow(db, workflow=workflow, workflow_spec=spec, user=_make_user())
+
+    persisted = json.loads(workflow.spec_json)
+    assert persisted["workflow"]["uuid"] == "server-generated-uuid"


### PR DESCRIPTION
create_workflow() assigns each task node in the workflow spec a uuid via replace_uuids(), and run_workflow() persists that spec to workflow.spec_json. get_task_signature() always generates a fresh, server-side uuid for the DB Task row (required: workflow_spec is an unvalidated client dict -- WorkflowRunRequest.workflow_spec -- so trusting a caller-supplied uuid here would let one tenant target another tenant's real, in-flight Celery task_id and collide with its Redis result-backend entry per #220 ).

The change in #220 surfaced a bug in ordering: run_workflow() persisted spec_json BEFORE create_workflow_signature() walked the tree and overwrote every node's uuid with the one actually dispatched to Celery, so the persisted spec permanently diverged from the DB task rows. The frontend UI matches DB tasks to spec nodes by uuid (WorkflowTreeNode.vue's celeryTask()), so this silently broke live task-status UI rendering for every workflow run.

Fix: persist spec_json only after create_workflow_signature() has finished assigning every node's uuid, not before.