### PR TITLE
Markdown support for file previews

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "sse-starlette>=2.3.6,<3.0.0",
     "duckdb>=1.3.2,<2.0.0",
     "pytz>=2026.1.post1,<2027.0",
+    "markdown>=3.6.0,<4.0.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "duckdb>=1.3.2,<2.0.0",
     "pytz>=2026.1.post1,<2027.0",
     "markdown>=3.6.0,<4.0.0",
+    "nh3>=0.2.20,<0.3.0",
 ]
 
 [dependency-groups]

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -112,11 +112,18 @@ def get_file_content(
             continue
     background_color = "#fff"
     font_color = "#000"
+    border_color = "#d0d7de"
+    code_bg = "#f6f8fa"
+    table_header_bg = "#f6f8fa"
     scrollbar_track_color = "#fff"
     scrollbar_thumb_color = "#ddd"
+
     if theme == "dark":
         background_color = "#0e172a"
         font_color = "#fff"
+        border_color = "#30363d"
+        code_bg = "#161b22"
+        table_header_bg = "#161b22"
         scrollbar_track_color = "#000"
         scrollbar_thumb_color = "#333"
 
@@ -132,9 +139,63 @@ def get_file_content(
             extensions=["tables", "fenced_code", "nl2br", "sane_lists"]
         )
         html_content = f"""
+        <!DOCTYPE html>
         <html style="background:{background_color}; scrollbar-color: {scrollbar_thumb_color} {scrollbar_track_color};">
-            <body style="color:{font_color}; padding: 16px; margin: 0; font-family: sans-serif; line-height: 1.6;">
-                {rendered_md}
+            <head>
+                <style>
+                    body {{
+                        margin: 0;
+                        padding: 16px;
+                        background: {background_color};
+                        color: {font_color};
+                        font-family: sans-serif;
+                    }}
+                    .markdown-body table {{
+                        border-collapse: collapse;
+                        width: 100%;
+                        margin-bottom: 16px;
+                    }}
+                    .markdown-body table th, .markdown-body table td {{
+                        padding: 6px 13px;
+                        border: 1px solid {border_color};
+                    }}
+                    .markdown-body table th {{
+                        font-weight: 600;
+                        background-color: {table_header_bg};
+                    }}
+                    .markdown-body ul, .markdown-body ol {{
+                        padding-left: 2em;
+                        margin-bottom: 16px;
+                    }}
+                    .markdown-body blockquote {{
+                        padding: 0 1em;
+                        margin: 0 0 16px 0;
+                        border-left: 4px solid {border_color};
+                        opacity: 0.85;
+                    }}
+                    .markdown-body code {{
+                        font-family: monospace;
+                        background-color: {code_bg};
+                        padding: 0.2em 0.4em;
+                        border-radius: 4px;
+                    }}
+                    .markdown-body pre {{
+                        background-color: {code_bg};
+                        padding: 12px;
+                        border-radius: 6px;
+                        overflow-x: auto;
+                        margin: 0 0 16px 0;
+                    }}
+                    .markdown-body pre code {{
+                        background: transparent;
+                        padding: 0;
+                    }}
+                </style>
+            </head>
+            <body>
+                <div class="markdown-body">
+                    {rendered_md}
+                </div>
             </body>
         </html>
         """

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -133,6 +133,8 @@ def get_file_content(
         or (file.magic_mime and file.magic_mime.lower() in ["text/markdown", "text/x-markdown"])
     )
 
+    csp_nonce = uuid4().hex
+
     if is_markdown:
         rendered_md = markdown.markdown(
             content,
@@ -140,9 +142,15 @@ def get_file_content(
         )
         html_content = f"""
         <!DOCTYPE html>
-        <html style="background:{background_color}; scrollbar-color: {scrollbar_thumb_color} {scrollbar_track_color};">
+        <html>
             <head>
-                <style>
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-{csp_nonce}'; script-src 'none'; img-src data: http: https:; object-src 'none'; frame-src 'none';">
+                <base target="_blank" rel="noopener noreferrer">
+                <style nonce="{csp_nonce}">
+                    html {{
+                        background: {background_color};
+                        scrollbar-color: {scrollbar_thumb_color} {scrollbar_track_color};
+                    }}
                     body {{
                         margin: 0;
                         padding: 16px;

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from typing import List
 from uuid import uuid4
 
+import markdown
 import aiofiles
 import redis
 from fastapi import (
@@ -119,18 +120,37 @@ def get_file_content(
         scrollbar_track_color = "#000"
         scrollbar_thumb_color = "#333"
 
-    html_source_content = html.escape(content)
-    if unescaped:
-        if file.data_type in ALLOWED_DATA_TYPES_PREVIEW:
-            html_source_content = content
+    is_markdown = (
+        (file.extension and file.extension.lower() in ["md", "markdown"])
+        or (file.display_name and file.display_name.lower().endswith((".md", ".markdown")))
+        or (file.magic_mime and file.magic_mime.lower() in ["text/markdown", "text/x-markdown"])
+    )
 
-    html_content = f"""
-    <html style="background:{background_color}; scrollbar-color: {scrollbar_thumb_color} {scrollbar_track_color};">
-        <body style="margin: 0;">
-            <pre style="color:{font_color};padding:10px;white-space: pre-wrap; margin: 0; padding: 0;">{html_source_content}</pre>
-        </body>
-    </html>
-    """
+    if is_markdown:
+        rendered_md = markdown.markdown(
+            content,
+            extensions=["tables", "fenced_code", "nl2br", "sane_lists"]
+        )
+        html_content = f"""
+        <html style="background:{background_color}; scrollbar-color: {scrollbar_thumb_color} {scrollbar_track_color};">
+            <body style="color:{font_color}; padding: 16px; margin: 0; font-family: sans-serif; line-height: 1.6;">
+                {rendered_md}
+            </body>
+        </html>
+        """
+    else:
+        html_source_content = html.escape(content)
+        if unescaped:
+            if file.data_type in ALLOWED_DATA_TYPES_PREVIEW:
+                html_source_content = content
+
+        html_content = f"""
+        <html style="background:{background_color}; scrollbar-color: {scrollbar_thumb_color} {scrollbar_track_color};">
+            <body style="margin: 0;">
+                <pre style="color:{font_color};padding:10px;white-space: pre-wrap; margin: 0; padding: 0;">{html_source_content}</pre>
+            </body>
+        </html>
+        """
     # return content
     return HTMLResponse(content=html_content, status_code=200)
 

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -21,6 +21,7 @@ from typing import List
 from uuid import uuid4
 
 import markdown
+import nh3
 import aiofiles
 import redis
 from fastapi import (
@@ -86,6 +87,29 @@ def get_file(
     return get_file_from_db(db, int(file_id))
 
 
+def sanitize_html(html_content: str) -> str:
+    """Sanitizes HTML content using nh3."""
+    return nh3.clean(
+        html_content,
+        tags={
+            "p", "div", "span", "br", "hr",
+            "h1", "h2", "h3", "h4", "h5", "h6",
+            "strong", "em", "b", "i", "code", "pre", "blockquote",
+            "ul", "ol", "li",
+            "table", "thead", "tbody", "tr", "th", "td",
+            "a", "img",
+        },
+        attributes={
+            "a": {"href", "title", "target"},
+            "img": {"src", "alt", "title"},
+            "code": {"class"},
+            "div": {"class"},
+        },
+        url_schemes={"http", "https", "mailto"},
+        link_rel="noopener noreferrer nofollow",
+    )
+
+
 # Get file content
 @router.get("/{file_id}/content", response_class=HTMLResponse)
 @require_access(allowed_roles=[Role.VIEWER, Role.EDITOR, Role.OWNER])
@@ -136,10 +160,11 @@ def get_file_content(
     csp_nonce = uuid4().hex
 
     if is_markdown:
-        rendered_md = markdown.markdown(
+        raw_md = markdown.markdown(
             content,
             extensions=["tables", "fenced_code", "nl2br", "sane_lists"]
         )
+        rendered_md = sanitize_html(raw_md)
         html_content = f"""
         <!DOCTYPE html>
         <html>
@@ -211,7 +236,7 @@ def get_file_content(
         html_source_content = html.escape(content)
         if unescaped:
             if file.data_type in ALLOWED_DATA_TYPES_PREVIEW:
-                html_source_content = content
+                html_source_content = sanitize_html(content)
 
         html_content = f"""
         <html style="background:{background_color}; scrollbar-color: {scrollbar_thumb_color} {scrollbar_track_color};">
@@ -220,7 +245,6 @@ def get_file_content(
             </body>
         </html>
         """
-    # return content
     return HTMLResponse(content=html_content, status_code=200)
 
 

--- a/src/tests/api/v1/files_test.py
+++ b/src/tests/api/v1/files_test.py
@@ -60,6 +60,32 @@ def test_get_file_content(
     mock_open.assert_called_with(expected_path, "r", encoding="utf-8")
 
 
+def test_get_file_content_markdown(
+    fastapi_test_client,
+    mocker,
+    file_db_model,
+    setup_file_path_mock,
+):
+    """Test the get_file_content endpoint for markdown files."""
+    file_db_model.extension = "md"
+    file_db_model.display_name = "test.md"
+    file_db_model.magic_mime = "text/markdown"
+
+    mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
+    mock_get_file_from_db.return_value = file_db_model
+    file_content = "# Hello World\n\nThis is **bold** text."
+    mock_open = mocker.mock_open(read_data=file_content)
+    mocker.patch("builtins.open", mock_open)
+
+    response = fastapi_test_client.get(
+        f"/files/{file_db_model.id}/content?theme=light"
+    )
+
+    assert response.status_code == 200
+    assert "<h1>Hello World</h1>" in response.text
+    assert "This is <strong>bold</strong> text." in response.text
+
+
 def test_get_file_content_file_not_found(
     fastapi_test_client, mocker, file_db_model, setup_file_path_mock
 ):

--- a/src/tests/api/v1/files_test.py
+++ b/src/tests/api/v1/files_test.py
@@ -86,6 +86,41 @@ def test_get_file_content_markdown(
     assert "This is <strong>bold</strong> text." in response.text
 
 
+def test_get_file_content_markdown_sanitization(
+    fastapi_test_client,
+    mocker,
+    file_db_model,
+    setup_file_path_mock,
+):
+    """Test that get_file_content sanitizes dangerous HTML/Markdown payloads."""
+    file_db_model.extension = "md"
+    file_db_model.display_name = "malicious.md"
+    file_db_model.magic_mime = "text/markdown"
+
+    mock_get_file_from_db = mocker.patch("api.v1.files.get_file_from_db")
+    mock_get_file_from_db.return_value = file_db_model
+    file_content = (
+        "# Title\n\n"
+        "<script>alert('xss');</script>\n"
+        "<style>body { background: red; }</style>\n"
+        "<img src=x onerror=alert(1)>\n"
+        "[Dangerous](javascript:alert(1))"
+    )
+    mock_open = mocker.mock_open(read_data=file_content)
+    mocker.patch("builtins.open", mock_open)
+
+    response = fastapi_test_client.get(
+        f"/files/{file_db_model.id}/content?theme=light"
+    )
+
+    assert response.status_code == 200
+    assert "<h1>Title</h1>" in response.text
+    assert "<script>" not in response.text
+    assert "<style>body" not in response.text
+    assert "onerror" not in response.text
+    assert 'href="javascript:' not in response.text
+
+
 def test_get_file_content_file_not_found(
     fastapi_test_client, mocker, file_db_model, setup_file_path_mock
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -1234,6 +1234,39 @@ wheels = [
 ]
 
 [[package]]
+name = "nh3"
+version = "0.2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/36/47a2b527c65321ffa4f3231dadccb995fb8737a07a9f837d4a72b4442ad6/nh3-0.2.22.tar.gz", hash = "sha256:dbfaa924ba226331c75896a64fe161a0cbd21172e4da687b2a69b5101db2c3e9", size = 18326, upload-time = "2025-07-15T13:01:46.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/cb/72c9173b4dcb86d1afbc0e39336c9272c5a8a468d3c0f931202d8d56e840/nh3-0.2.22-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:4743c9132e2ccf2109af88ce16074c5a7068df85be8f7b9840dbe683e50b9461", size = 1376436, upload-time = "2025-07-15T13:01:13.722Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f7/6bc7f88dac93971eaad9d5f01576e946c920c479c7f1a3f32e25b470e17a/nh3-0.2.22-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca015dbd477e20a29bee8660a966523c677da0c34dfeb474c6acb64462fbfc15", size = 771664, upload-time = "2025-07-15T13:01:15.346Z" },
+    { url = "https://files.pythonhosted.org/packages/11/06/b24ea80bcc3f1606f1152164ef7b0abc74d776cd1966912bd43e9d1fb232/nh3-0.2.22-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9d10f4c195f3b84a8127417ec940e1393062a3e2f05d405270dde7846854e22c", size = 804369, upload-time = "2025-07-15T13:01:16.974Z" },
+    { url = "https://files.pythonhosted.org/packages/18/74/7cfee6348a2afbbb6434c9d74131bba421d3e372d683bdf4b7961ff19069/nh3-0.2.22-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9bbeb3d253c1026a46e7b23bc2698fe1f00641b5a7bdad8e4c8937daaa1f2b51", size = 965567, upload-time = "2025-07-15T13:01:18.288Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f2/9250a435feebd078adccfcccf880ddce1923d653bcc6ac30eb5acb16c7e3/nh3-0.2.22-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:b71ea8e987923e2976a99e4bb17e39cc186c93a330712075650e6143cb2fa89b", size = 1043132, upload-time = "2025-07-15T13:01:19.629Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f2/87b10ba4706915292dc1aec63ef975abd30b22cbe7d75f750792174c207b/nh3-0.2.22-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:56b328457370401aaf2039a5039d7f587e72b2c08bc95dfe807ad96ae98e83e4", size = 965457, upload-time = "2025-07-15T13:01:21.541Z" },
+    { url = "https://files.pythonhosted.org/packages/90/10/b03c17a142805b87fca4e6841a88cdc82830e697ef91faae23533eb25052/nh3-0.2.22-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e9762845ee47372df425b52ec4a133e994dbbedf95ad61eea4bfe6cb4d1401b4", size = 951401, upload-time = "2025-07-15T13:01:23.019Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8b/68e2ae236a9a1f3d68bda5cc1984630ecc7bf217b8416cc6a973d021e9cc/nh3-0.2.22-cp313-cp313t-win32.whl", hash = "sha256:c61fbfe4131ceff1c83ed0663c39aebb72bd26c6b22157b14da0b43287ea15ed", size = 566170, upload-time = "2025-07-15T13:01:24.144Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/88/4e04f39e0582f3f2b3d39d843fd0eacfcd5d3400c93a688d9035279ccd9b/nh3-0.2.22-cp313-cp313t-win_amd64.whl", hash = "sha256:4f47991a9819f644918aebc2a93d175562c7c0c2ec41cbc525fbdbf676793c03", size = 574528, upload-time = "2025-07-15T13:01:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/46/4061064aff600d0770a7bf1d11d66555a0000ce5fb9ea35963814061776d/nh3-0.2.22-cp313-cp313t-win_arm64.whl", hash = "sha256:29baf3c22d6e9d26325128600355baeddb52eecd6206780621f84537ad4db966", size = 558648, upload-time = "2025-07-15T13:01:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/41/95/cc1dfd35caf08a1299659d29b7c705e09f71a3264c764b787a4d173c7ab0/nh3-0.2.22-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2a6e33de39218eded7187aaf05aea71884b1b8002d50d080a95df734d3ad3a44", size = 1390150, upload-time = "2025-07-15T13:01:28.362Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/877529f1f8fab696fc92eafed30165db7a4c9ececad797d5963527460c63/nh3-0.2.22-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb91663dcf139da2009d452aad23094e01579c45a6101b2a0b0c28181b8c496f", size = 796899, upload-time = "2025-07-15T13:01:29.523Z" },
+    { url = "https://files.pythonhosted.org/packages/51/38/2795eaa63210a6128b799598ab478605004af3bd22c1c7df70e0041424a5/nh3-0.2.22-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f45f8a2347da8c9682f9b015cf9d492fdb8440cfb7bd523cceda1a705fd5a4bd", size = 783783, upload-time = "2025-07-15T13:01:30.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/c32928682c0562a92bfb200919189387645e3bf09b79948ccfbb0fa13b5e/nh3-0.2.22-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f94ed44f433e2f8799f5285000f799e9f3ca66559328e40066c0f96c4fbad346", size = 994730, upload-time = "2025-07-15T13:01:31.841Z" },
+    { url = "https://files.pythonhosted.org/packages/af/43/c382b1fca4e503f63f83d38897c73327f592e6d23a2c5b2689a8f2925478/nh3-0.2.22-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:74039dfd41107bbb298fe814c4be5c39d66124855ff549d216e4947a69d3d9a1", size = 948349, upload-time = "2025-07-15T13:01:32.984Z" },
+    { url = "https://files.pythonhosted.org/packages/36/21/15987b0809147caac82d9121d7459bed79f7720c3b1211ca7f9fa7b7cb0f/nh3-0.2.22-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:60e1d4429762745a5a346277dc3378aade0e24632f75077f0da3bfc29bf385fd", size = 897381, upload-time = "2025-07-15T13:01:34.104Z" },
+    { url = "https://files.pythonhosted.org/packages/67/58/41ea85e83d239cd964b00a59ac88a5f9a5b95de8ceebb498b370e818da52/nh3-0.2.22-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e9e93c67d1ec8db6d96e323832bd267cdfe94bdb8cc6adc88cbc0908ff59329", size = 777724, upload-time = "2025-07-15T13:01:35.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c0/dc723ba6c84409ff5498ca023bd11f0066a9e6349e896fb5447f99fab5f5/nh3-0.2.22-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7f186eea285ebf941fbaaecd1cd445e9506552a15435140ca73ca029334715da", size = 810348, upload-time = "2025-07-15T13:01:36.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d7/6a83583072778aaee6895630fe78e0e35de2d8cabeddf3b42db39cbc2105/nh3-0.2.22-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87e532f885937c460ccbdc1b5ea03b0e420de8ef12dd5857621706298857b9aa", size = 972880, upload-time = "2025-07-15T13:01:38.163Z" },
+    { url = "https://files.pythonhosted.org/packages/22/27/652cba516e29e761bda99523af498380f1b1eb92ef82a691225125055009/nh3-0.2.22-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:fee209eb0d93830908e4f6fc549c08766def701f5681de2779637a00d48f288f", size = 1048447, upload-time = "2025-07-15T13:01:39.31Z" },
+    { url = "https://files.pythonhosted.org/packages/21/81/1016f07ec672195803991ce5c91f059a10e438e6bdf3cd3abe304dea284f/nh3-0.2.22-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:10e8d0a833431860620f7f1434792607ca12cdfda81450a2678b8d69642eda69", size = 971729, upload-time = "2025-07-15T13:01:40.51Z" },
+    { url = "https://files.pythonhosted.org/packages/99/cf/ea5fc35a5f5c4b5729c557cf95df8f124fa731bc1414ab338b71003d63af/nh3-0.2.22-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:adbb35826fad998f88f68b969e3936dff53b70052c9e6e951ef9e49db9590611", size = 956978, upload-time = "2025-07-15T13:01:41.56Z" },
+    { url = "https://files.pythonhosted.org/packages/11/bf/dd35d217034564dc0cab66b20c17b918a646e50b2c498728021d878d5770/nh3-0.2.22-cp38-abi3-win32.whl", hash = "sha256:bcac2a186791c422ce55522cae332c8fa2135795b7b510e2475cb95a44f7b0ce", size = 572115, upload-time = "2025-07-15T13:01:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/78/7b/fd742f962fef24f8432500381b339b220747ffdb2d654f15e620b22a9c9a/nh3-0.2.22-cp38-abi3-win_amd64.whl", hash = "sha256:a78a13f5bf5901f5de50580a74058a10734d3e836144cb090f0304ec5deb3df7", size = 578434, upload-time = "2025-07-15T13:01:44.022Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/50/5a5e05b011cb1feb28ee789bcb64d4e9f5fa145c6533001bffadec8448d7/nh3-0.2.22-cp38-abi3-win_arm64.whl", hash = "sha256:602ad5229c81a287c8632ea1bf2d6b3654b3e208b57b0bcab5beec93ff91866f", size = 563625, upload-time = "2025-07-15T13:01:45.084Z" },
+]
+
+[[package]]
 name = "ollama"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1316,6 +1349,7 @@ dependencies = [
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "markdown" },
+    { name = "nh3" },
     { name = "openrelik-ai-common" },
     { name = "openrelik-common" },
     { name = "prometheus-client" },
@@ -1357,6 +1391,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
     { name = "itsdangerous", specifier = ">=2.1.2,<3.0.0" },
     { name = "markdown", specifier = ">=3.6.0,<4.0.0" },
+    { name = "nh3", specifier = ">=0.2.20,<0.3.0" },
     { name = "openrelik-ai-common", specifier = ">=0.6.0,<0.7.0" },
     { name = "openrelik-common", specifier = ">=0.7.9,<0.8.0" },
     { name = "prometheus-client", specifier = ">=0.21.0,<0.22.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1111,6 +1111,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1306,6 +1315,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "httpx" },
     { name = "itsdangerous" },
+    { name = "markdown" },
     { name = "openrelik-ai-common" },
     { name = "openrelik-common" },
     { name = "prometheus-client" },
@@ -1346,6 +1356,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.29.0,<3.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
     { name = "itsdangerous", specifier = ">=2.1.2,<3.0.0" },
+    { name = "markdown", specifier = ">=3.6.0,<4.0.0" },
     { name = "openrelik-ai-common", specifier = ">=0.6.0,<0.7.0" },
     { name = "openrelik-common", specifier = ">=0.7.9,<0.8.0" },
     { name = "prometheus-client", specifier = ">=0.21.0,<0.22.0" },


### PR DESCRIPTION
This PR adds support for rendering html from markdown documents.

* Server side conversion
* Served in an iframe with sandboxing
* Sanitized html with nh3
* CSP policy to prevent script execution etc
* CSS for minimal styling of markdown content